### PR TITLE
Support empty lines in ASCII stl files

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -119,10 +119,10 @@ class BaseStl(base.BaseMesh):
                 line += lines.pop(0)
 
             line = line.lower().strip()
-            if prefix:
-                if line == b(''):
-                    return get(prefix)
+            if line == b(''):
+                return get(prefix)
 
+            if prefix:
                 if line.startswith(prefix):
                     values = line.replace(prefix, b(''), 1).strip().split()
                 elif line.startswith(b('endsolid')):

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -120,6 +120,9 @@ class BaseStl(base.BaseMesh):
 
             line = line.lower().strip()
             if prefix:
+                if line == b(''):
+                    return get(prefix)
+
                 if line.startswith(prefix):
                     values = line.replace(prefix, b(''), 1).strip().split()
                 elif line.startswith(b('endsolid')):

--- a/tests/stl_corruption.py
+++ b/tests/stl_corruption.py
@@ -40,6 +40,34 @@ def test_ascii_with_missing_name(tmpdir):
         mesh.Mesh.from_file(str(tmp_file), fh=fh)
 
 
+def test_ascii_with_blank_lines(tmpdir):
+    _stl_file = '''
+    solid test.stl
+
+
+      facet normal -0.014565 0.073223 -0.002897
+
+        outer loop
+
+          vertex 0.399344 0.461940 1.044090
+          vertex 0.500000 0.500000 1.500000
+
+          vertex 0.576120 0.500000 1.117320
+
+        endloop
+
+      endfacet
+
+    endsolid test.stl
+    '''.lstrip()
+
+    tmp_file = tmpdir.join('tmp.stl')
+    with tmp_file.open('w+') as fh:
+        fh.write(_stl_file)
+        fh.seek(0)
+        mesh.Mesh.from_file(str(tmp_file), fh=fh)
+
+
 def test_incomplete_ascii_file(tmpdir):
     tmp_file = tmpdir.join('tmp.stl')
     with tmp_file.open('w+') as fh:


### PR DESCRIPTION
The spec is vague on how to handle empty lines in an STL file.  Some say
its allowed others don't say anything.  Its best to support it and be
more flexible.