### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,9 +69,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = metadata.__package_name__.replace('-', ' ').capitalize()
-copyright = u'%s,  <a href="http://wol.ph/">%s</a>' % (
+copyright = u'{0!s},  <a href="http://wol.ph/">{1!s}</a>'.format(
     datetime.date.today().year,
-    metadata.__author__,
+    metadata.__author__
 )
 
 # The version info for the project you're documenting, acts as replacement for
@@ -224,8 +224,8 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [(
     'index',
-    '%s.tex' % metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    '{0!s}.tex'.format(metadata.__package_name__),
+    u'{0!s} Documentation'.format(metadata.__package_name__.replace('-', ' ').capitalize()),
    metadata.__author__,
    'manual',
 )]
@@ -258,7 +258,7 @@ latex_documents = [(
 man_pages = [(
     'index',
     metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    u'{0!s} Documentation'.format(metadata.__package_name__.replace('-', ' ').capitalize()),
     [metadata.__author__],
     1,
 )]
@@ -275,7 +275,7 @@ man_pages = [(
 texinfo_documents = [(
     'index',
     metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    u'{0!s} Documentation'.format(metadata.__package_name__.replace('-', ' ').capitalize()),
     metadata.__author__,
     metadata.__package_name__,
     metadata.__description__,

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open('stl/__about__.py') as fp:
 if os.path.isfile('README.rst'):
     long_description = open('README.rst').read()
 else:
-    long_description = 'See http://pypi.python.org/pypi/%s/' % (
-        about['__package_name__'])
+    long_description = 'See http://pypi.python.org/pypi/{0!s}/'.format((
+        about['__package_name__']))
 
 install_requires = [
     'numpy',
@@ -43,9 +43,9 @@ if __name__ == '__main__':
         setup_requires=['pytest-runner'],
         entry_points={
             'console_scripts': [
-                'stl = %s.main:main' % about['__import_name__'],
-                'stl2ascii = %s.main:to_ascii' % about['__import_name__'],
-                'stl2bin = %s.main:to_binary' % about['__import_name__'],
+                'stl = {0!s}.main:main'.format(about['__import_name__']),
+                'stl2ascii = {0!s}.main:to_ascii'.format(about['__import_name__']),
+                'stl2bin = {0!s}.main:to_binary'.format(about['__import_name__']),
             ],
         },
         classifiers=['License :: OSI Approved :: BSD License'],

--- a/stl/base.py
+++ b/stl/base.py
@@ -293,15 +293,15 @@ class BaseMesh(logger.Logged, collections.Mapping):
 
     def _get_or_update(key):
         def _get(self):
-            if not hasattr(self, '_%s' % key):
-                getattr(self, 'update_%s' % key)()
-            return getattr(self, '_%s' % key)
+            if not hasattr(self, '_{0!s}'.format(key)):
+                getattr(self, 'update_{0!s}'.format(key))()
+            return getattr(self, '_{0!s}'.format(key))
 
         return _get
 
     def _set(key):
         def _set(self, value):
-            setattr(self, '_%s' % key, value)
+            setattr(self, '_{0!s}'.format(key), value)
 
         return _set
 

--- a/stl/main.py
+++ b/stl/main.py
@@ -27,7 +27,7 @@ def _get_name(args):
         args.name,
         getattr(args.outfile, 'name', None),
         getattr(args.infile, 'name', None),
-        'numpy-stl-%06d' % random.randint(0, 1e6),
+        'numpy-stl-{0:06d}'.format(random.randint(0, 1e6)),
     ]
 
     for name in names:  # pragma: no branch

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -129,14 +129,14 @@ class BaseStl(base.BaseMesh):
                     raise StopIteration()
                 else:
                     raise RuntimeError(recoverable[0],
-                                       '%r should start with %r' % (line,
+                                       '{0!r} should start with {1!r}'.format(line,
                                                                     prefix))
 
                 if len(values) == 3:
                     return [float(v) for v in values]
                 else:  # pragma: no cover
                     raise RuntimeError(recoverable[0],
-                                       'Incorrect value %r' % line)
+                                       'Incorrect value {0!r}'.format(line))
             else:
                 return b(line)
 
@@ -203,7 +203,7 @@ class BaseStl(base.BaseMesh):
         elif mode is ASCII:
             write = self._write_ascii
         else:
-            raise ValueError('Mode %r is invalid' % mode)
+            raise ValueError('Mode {0!r} is invalid'.format(mode))
 
         name = os.path.split(filename)[-1]
         try:
@@ -217,29 +217,29 @@ class BaseStl(base.BaseMesh):
 
     def _write_ascii(self, fh, name):
         def p(s, file):
-            file.write(b('%s\n' % s))
+            file.write(b('{0!s}\n'.format(s)))
 
-        p('solid %s' % name, file=fh)
+        p('solid {0!s}'.format(name), file=fh)
 
         for row in self.data:
             vectors = row['vectors']
-            p('facet normal %f %f %f' % tuple(row['normals']), file=fh)
+            p('facet normal {0:f} {1:f} {2:f}'.format(*tuple(row['normals'])), file=fh)
             p('  outer loop', file=fh)
-            p('    vertex %f %f %f' % tuple(vectors[0]), file=fh)
-            p('    vertex %f %f %f' % tuple(vectors[1]), file=fh)
-            p('    vertex %f %f %f' % tuple(vectors[2]), file=fh)
+            p('    vertex {0:f} {1:f} {2:f}'.format(*tuple(vectors[0])), file=fh)
+            p('    vertex {0:f} {1:f} {2:f}'.format(*tuple(vectors[1])), file=fh)
+            p('    vertex {0:f} {1:f} {2:f}'.format(*tuple(vectors[2])), file=fh)
             p('  endloop', file=fh)
             p('endfacet', file=fh)
 
-        p('endsolid %s' % name, file=fh)
+        p('endsolid {0!s}'.format(name), file=fh)
 
     def _write_binary(self, fh, name):
         # Create the header
-        header = '%s (%s) %s %s' % (
+        header = '{0!s} ({1!s}) {2!s} {3!s}'.format(
             metadata.__package_name__,
             metadata.__version__,
             datetime.datetime.now(),
-            name,
+            name
         )
 
         # Make it exactly 80 characters


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:WoLpH:numpy-stl?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:WoLpH:numpy-stl?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)