### PR TITLE
Modified stl.py to correctly handle multi-part stl files. The _ascii_…

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -130,6 +130,9 @@ class BaseStl(base.BaseMesh):
                 if line.startswith(prefix):
                     values = line.replace(prefix, b(''), 1).strip().split()
                 elif line.startswith(b('endsolid')):
+                    # go back to the beginning of new solid part
+                    size_unprocessedlines = sum([len(l + b('\n')) for l in lines]) - len('\n')
+                    fh.seek(-1 * size_unprocessedlines, 1)
                     raise StopIteration()
                 else:
                     raise RuntimeError(recoverable[0],


### PR DESCRIPTION
…reader read beyond the 'endsolid' so the header of the next part was wrong! Fix proposed in lines 133-135