### PR TITLE
Facet (Triangle) Exception addition

### DIFF
--- a/stl/base.py
+++ b/stl/base.py
@@ -30,6 +30,14 @@ X = Dimension.X
 Y = Dimension.Y
 Z = Dimension.Z
 
+class FacetError(Exception):
+    def __init__(self, eType, msg):
+        self.args = [eType, msg]
+        self.type = eType
+        self.msg = msg
+    def __str__(self):
+        return ('Missing Vertex. ' if self.type==-1 else 'Extra Vertex. ') + self.msg
+
 
 class RemoveDuplicates(enum.Enum):
     '''

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -67,6 +67,8 @@ class BaseStl(base.BaseMesh):
             try:
                 name, data = cls._load_ascii(
                     fh, header, speedups=speedups)
+            except base.FacetError as exception:
+                raise exception
             except RuntimeError as exception:
                 (recoverable, e) = exception.args
                 # If we didn't read beyond the header the stream is still
@@ -158,9 +160,7 @@ class BaseStl(base.BaseMesh):
                         fh.seek(position - size_unprocessedlines)
                     raise StopIteration()
                 else:
-                    raise RuntimeError(recoverable[0],
-                                       '%r should start with %r' % (line,
-                                                                    prefix))
+                    raise base.FacetError(-1, 'Missing vertex (expected 3)')
 
                 if len(values) == 3:
                     return [float(v) for v in values]
@@ -202,7 +202,7 @@ class BaseStl(base.BaseMesh):
                 attrs = 0
                 yield (normals, (v0, v1, v2), attrs)
             except AssertionError as e:  # pragma: no cover
-                raise RuntimeError(recoverable[0], e)
+                raise base.FacetError(1, 'Extra vertex (expected 3) or missing endloop/endfacet keyword.')
             except StopIteration:
                 raise
 


### PR DESCRIPTION
I added a custom exception (that bubbles up) to give some feedback when the ASCII reader returns certain types of errors:

- a missing vertex in a facet
- an extra vertex in a facet

I added this because the fallback to the Binary reader was being invoked when an ASCII STL had the above issues. This is incorrect, and opened the door for possible raises of the 1 million `MAX_COUNT` exception although this is not the actual error with the file.

I'm not 100% sure that I like this approach, but there needs to be a bit more thought on the ASCII/Binary decision logic in the future so that the `MAX_COUNT` cutoff can be eliminated, or increased substantially.