### PR TITLE
Ensure py2 compatibility

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -286,7 +286,7 @@ class BaseStl(base.BaseMesh):
 
         # Make it exactly 80 characters
         header = header[:80].ljust(80, ' ')
-        packed = struct.pack('@i', self.data.size)
+        packed = struct.pack(s('@i'), self.data.size)
 
         if isinstance(fh, io.TextIOWrapper):  # pragma: no cover
             packed = str(packed)


### PR DESCRIPTION
Fix issue described in https://github.com/WoLpH/numpy-stl/issues/10

_load_binary is correct this one fixes _write_binary 

