### PR TITLE
Always use little endian when loading/saving binary STLs

### DIFF
--- a/stl/base.py
+++ b/stl/base.py
@@ -145,6 +145,7 @@ class BaseMesh(logger.Logged, collections.Mapping):
         (s('vectors'), numpy.float32, (3, 3)),
         (s('attr'), numpy.uint16, (1, )),
     ])
+    dtype = dtype.newbyteorder('<')  # Even on big endian arches, use little e.
 
     def __init__(self, data, calculate_normals=True,
                  remove_empty_areas=False,

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -97,7 +97,7 @@ class BaseStl(base.BaseMesh):
         if len(count_data) != COUNT_SIZE:
             count = 0
         else:
-            count, = struct.unpack(s('@i'), b(count_data))
+            count, = struct.unpack(s('<i'), b(count_data))
         # raise RuntimeError()
         assert count < MAX_COUNT, ('File too large, got %d triangles which '
                                    'exceeds the maximum of %d') % (
@@ -286,7 +286,7 @@ class BaseStl(base.BaseMesh):
 
         # Make it exactly 80 characters
         header = header[:80].ljust(80, ' ')
-        packed = struct.pack(s('@i'), self.data.size)
+        packed = struct.pack(s('<i'), self.data.size)
 
         if isinstance(fh, io.TextIOWrapper):  # pragma: no cover
             packed = str(packed)

--- a/tests/stl_corruption.py
+++ b/tests/stl_corruption.py
@@ -99,7 +99,7 @@ def test_corrupt_ascii_file(tmpdir, speedups):
         fh.seek(40)
         print(' ' * 100, file=fh)
         fh.seek(80)
-        fh.write(struct.pack('@i', 10).decode('utf-8'))
+        fh.write(struct.pack('<i', 10).decode('utf-8'))
         fh.seek(0)
         with pytest.raises(AssertionError):
             mesh.Mesh.from_file(str(tmp_file), fh=fh, speedups=speedups)


### PR DESCRIPTION
This is neccessary to make this work on big endian architectures,
up until now the saving and loading was arch specific.

Binary STLs saved as little endian (most of the existing STLs)
were not compatible with numpy-stl running on big endian system.

Fixes https://github.com/WoLpH/numpy-stl/issues/43