### PR TITLE
Split tests that run multiple checks into parametrzied ones

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,11 @@ def binary_path(cwd):
     return cwd.join('stl_binary')
 
 
+@pytest.fixture(scope='session', params=['ascii', 'binary'])
+def binary_ascii_path(request, ascii_path, binary_path):
+    return ascii_path if request.param == 'ascii' else binary_path
+
+
 @pytest.fixture(scope='session')
 def ascii_file(ascii_path):
     return str(ascii_path.join('HalfDonut.stl'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,26 +8,26 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize('speedups', [False, True])
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def cwd():
     return py.path.local(__file__).dirpath()
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def ascii_path(cwd):
     return cwd.join('stl_ascii')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def binary_path(cwd):
     return cwd.join('stl_binary')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def ascii_file(ascii_path):
     return str(ascii_path.join('HalfDonut.stl'))
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def binary_file(binary_path):
     return str(binary_path.join('HalfDonut.stl'))

--- a/tests/test_meshProperties.py
+++ b/tests/test_meshProperties.py
@@ -1,4 +1,5 @@
 import numpy
+import pytest
 
 from stl import stl
 
@@ -6,51 +7,50 @@ from stl import stl
 tolerance = 1e-6
 
 
-def test_mass_properties_for_half_donut(ascii_path, binary_path, speedups):
+def test_mass_properties_for_half_donut(binary_ascii_path, speedups):
     """
     Checks the results of method get_mass_properties() on
     STL ASCII and binary files HalfDonut.stl
     One checks the results obtained with stl
     with the ones obtained with meshlab
     """
-    for path in (ascii_path, binary_path):
-        filename = path.join('HalfDonut.stl')
-        mesh = stl.StlMesh(str(filename), speedups=speedups)
-        volume, cog, inertia = mesh.get_mass_properties()
-        assert(abs(volume - 2.343149) < tolerance)
-        assert(numpy.allclose(cog,
-               numpy.array([1.500001, 0.209472, 1.500001]),
-               atol=tolerance))
-        assert(numpy.allclose(inertia,
-               numpy.array([[+1.390429, +0.000000, +0.000000],
-                            [+0.000000, +2.701025, +0.000000],
-                            [+0.000000, +0.000000, +1.390429]]),
-               atol=tolerance))
+    filename = binary_ascii_path.join('HalfDonut.stl')
+    mesh = stl.StlMesh(str(filename), speedups=speedups)
+    volume, cog, inertia = mesh.get_mass_properties()
+    assert(abs(volume - 2.343149) < tolerance)
+    assert(numpy.allclose(cog,
+           numpy.array([1.500001, 0.209472, 1.500001]),
+           atol=tolerance))
+    assert(numpy.allclose(inertia,
+           numpy.array([[+1.390429, +0.000000, +0.000000],
+                        [+0.000000, +2.701025, +0.000000],
+                        [+0.000000, +0.000000, +1.390429]]),
+           atol=tolerance))
 
 
-def test_mass_properties_for_moon(ascii_path, binary_path, speedups):
+def test_mass_properties_for_moon(binary_ascii_path, speedups):
     """
     Checks the results of method get_mass_properties() on
     STL ASCII and binary files Moon.stl
     One checks the results obtained with stl
     with the ones obtained with meshlab
     """
-    for path in (ascii_path, binary_path):
-        filename = path.join('Moon.stl')
-        mesh = stl.StlMesh(str(filename), speedups=speedups)
-        volume, cog, inertia = mesh.get_mass_properties()
-        assert(abs(volume - 0.888723) < tolerance)
-        assert(numpy.allclose(cog,
-               numpy.array([0.906913, 0.170731, 1.500001]),
-               atol=tolerance))
-        assert(numpy.allclose(inertia,
-               numpy.array([[+0.562097, -0.000457, +0.000000],
-                            [-0.000457, +0.656851, +0.000000],
-                            [+0.000000, +0.000000, +0.112465]]),
-               atol=tolerance))
+    filename = binary_ascii_path.join('Moon.stl')
+    mesh = stl.StlMesh(str(filename), speedups=speedups)
+    volume, cog, inertia = mesh.get_mass_properties()
+    assert(abs(volume - 0.888723) < tolerance)
+    assert(numpy.allclose(cog,
+           numpy.array([0.906913, 0.170731, 1.500001]),
+           atol=tolerance))
+    assert(numpy.allclose(inertia,
+           numpy.array([[+0.562097, -0.000457, +0.000000],
+                        [-0.000457, +0.656851, +0.000000],
+                        [+0.000000, +0.000000, +0.112465]]),
+           atol=tolerance))
 
 
-def test_mass_properties_for_star(ascii_path, binary_path, speedups):
+@pytest.mark.parametrize('filename', ('Star.stl', 'StarWithEmptyHeader.stl'))
+def test_mass_properties_for_star(binary_ascii_path, filename, speedups):
     """
     Checks the results of method get_mass_properties() on
     STL ASCII and binary files Star.stl and
@@ -58,17 +58,17 @@ def test_mass_properties_for_star(ascii_path, binary_path, speedups):
     One checks the results obtained with stl
     with the ones obtained with meshlab
     """
-    for filename in (ascii_path.join('Star.stl'),
-                     binary_path.join('Star.stl'),
-                     binary_path.join('StarWithEmptyHeader.stl')):
-        mesh = stl.StlMesh(str(filename), speedups=speedups)
-        volume, cog, inertia = mesh.get_mass_properties()
-        assert(abs(volume - 1.416599) < tolerance)
-        assert(numpy.allclose(cog,
-               numpy.array([1.299040, 0.170197, 1.499999]),
-               atol=tolerance))
-        assert(numpy.allclose(inertia,
-               numpy.array([[+0.509549, +0.000000, -0.000000],
-                            [+0.000000, +0.991236, +0.000000],
-                            [-0.000000, +0.000000, +0.509550]]),
-               atol=tolerance))
+    filename = binary_ascii_path.join(filename)
+    if not filename.exists():
+        pytest.skip('STL file does not exist')
+    mesh = stl.StlMesh(str(filename), speedups=speedups)
+    volume, cog, inertia = mesh.get_mass_properties()
+    assert(abs(volume - 1.416599) < tolerance)
+    assert(numpy.allclose(cog,
+           numpy.array([1.299040, 0.170197, 1.499999]),
+           atol=tolerance))
+    assert(numpy.allclose(inertia,
+           numpy.array([[+0.509549, +0.000000, -0.000000],
+                        [+0.000000, +0.991236, +0.000000],
+                        [-0.000000, +0.000000, +0.509550]]),
+           atol=tolerance))


### PR DESCRIPTION
When i was hunting down #43, I was a bit confused sometimes about what exactly is failing. Turns out, only binary files where the problem. This PR changes the testsuite so that it is quite obvious what failed if only binary or ASCII is the problem.

I've also changed the never-changing fixtures to be session scoped, it should (in theory) save some time.