### PR TITLE
Add about 100x faster translate function to example code.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,16 +341,9 @@ Combining multiple STL files
 
 
     def translate(_solid, step, padding, multiplier, axis):
-        if axis == 'x':
-            items = [0, 3, 6]
-        elif axis == 'y':
-            items = [1, 4, 7]
-        elif axis == 'z':
-            items = [2, 5, 8]
-        for p in _solid.points:
-            # point items are ((x, y, z), (x, y, z), (x, y, z))
-            for i in range(3):
-                p[items[i]] += (step * multiplier) + (padding * multiplier)
+        items = {'x': (0, 3, 6), 'y': (1, 4, 7), 'z': (2, 5, 8)}[axis]
+        # _solid.points.shape == [:, ((x, y, z), (x, y, z), (x, y, z))]
+        _solid.points[:, items] += (step * multiplier) + (padding * multiplier)
 
 
     def copy_obj(obj, dims, num_rows, num_cols, num_layers):


### PR DESCRIPTION
Benchmark:

```python
import numpy as np

def translate(_solid, step=0, padding=0, multiplier=1, axis='x'):
    assert axis in ('x', 'y', 'z')
    if 'x' == axis:
        items = [0, 3, 6]
    elif 'y' == axis:
        items = [1, 4, 7]
    elif 'z' == axis:
        items = [2, 5, 8]
    for p in _solid.points:
        # point items are ((x, y, z), (x, y, z), (x, y, z))
        for i in range(3):
            p[items[i]] += (step * multiplier) + (padding * multiplier)

def translate2(_solid, step=0, padding=0, multiplier=1, axis='x'):
    items = {'x': (0, 3, 6), 'y': (1, 4, 7), 'z': (2, 5, 8)}[axis]
    # _solid.points.shape == [:, ((x, y, z), (x, y, z), (x, y, z))]
    _solid.points[:, items] += (step * multiplier) + (padding * multiplier)

a = np.arange(1e4 * 9).reshape((-1, 9))

class MyDict(dict):
    pass

d = MyDict()
d.points = a.copy()

%timeit -n 1000 translate(d, step=0.645, padding=3, multiplier=2, axis='x')

d2 = MyDict()
d2.points = a.copy()

%timeit -n 1000 translate2(d2, step=0.645, padding=3, multiplier=2, axis='x')

print(np.array_equal(d.points, d2.points))

# 16.5 ms ± 281 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
# 155 µs ± 7.93 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
# True
```