### PR TITLE
Removed unnecessary nine dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ else:
 
 install_requires = [
     'numpy',
-    'nine',
     'python-utils>=1.6.2',
 ]
 


### PR DESCRIPTION
I wanted to prepare a [conda-forge](https://conda-forge.org/) package for `numpy-stl` (is it okay to add you as additional maintainer there?) and stumbled upon the `nine` dependency…
Upon closer inspection, I realized `nine` does not seem to be used anywhere…