### PR TITLE
Use numpy.allclose() in tests to check float arrays equality

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -33,12 +33,9 @@ def test_units_2d():
     mesh = Mesh(data, remove_empty_areas=False)
     mesh.update_units()
 
-    assert (mesh.areas == [.5, .5]).all()
-    assert (mesh.normals == [[0, 0, 1.],
-                             [0, 0, -1.]]).all()
-
-    assert (mesh.units == [[0, 0, 1],
-                           [0, 0, -1]]).all()
+    assert numpy.allclose(mesh.areas, [.5, .5])
+    assert numpy.allclose(mesh.normals, [[0, 0, 1.], [0, 0, -1.]])
+    assert numpy.allclose(mesh.units, [[0, 0, 1], [0, 0, -1]])
 
 
 def test_units_3d():
@@ -51,7 +48,7 @@ def test_units_3d():
     mesh.update_units()
 
     assert (mesh.areas - 2 ** .5) < 0.0001
-    assert (mesh.normals == [0, -1, 1]).all()
+    assert numpy.allclose(mesh.normals, [0, -1, 1])
 
     units = mesh.units[0]
     assert units[0] == 0
@@ -102,28 +99,28 @@ def test_duplicate_polygons():
     mesh = Mesh(data, remove_duplicate_polygons=True)
     assert mesh.data.size == 3
 
-    assert (mesh.vectors[0] == numpy.array([[1, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
-    assert (mesh.vectors[1] == numpy.array([[2, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
-    assert (mesh.vectors[2] == numpy.array([[0, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
+    assert numpy.allclose(mesh.vectors[0], numpy.array([[1, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
+    assert numpy.allclose(mesh.vectors[1], numpy.array([[2, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
+    assert numpy.allclose(mesh.vectors[2], numpy.array([[0, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
 
     mesh = Mesh(data, remove_duplicate_polygons=RemoveDuplicates.ALL)
     assert mesh.data.size == 3
 
-    assert (mesh.vectors[0] == numpy.array([[1, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
-    assert (mesh.vectors[1] == numpy.array([[2, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
-    assert (mesh.vectors[2] == numpy.array([[0, 0, 0],
-                                            [0, 0, 0],
-                                            [0, 0, 0]])).all()
+    assert numpy.allclose(mesh.vectors[0], numpy.array([[1, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
+    assert numpy.allclose(mesh.vectors[1], numpy.array([[2, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
+    assert numpy.allclose(mesh.vectors[2], numpy.array([[0, 0, 0],
+                                                        [0, 0, 0],
+                                                        [0, 0, 0]]))
 
 
 def test_remove_all_duplicate_polygons():

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -49,14 +49,16 @@ def test_rotation():
     # substracting .5
     data['vectors'] += .5
 
-    assert (mesh.vectors == numpy.array([
+    # We use a slightly higher absolute tolerance here, for ppc64le
+    # https://github.com/WoLpH/numpy-stl/issues/78
+    assert numpy.allclose(mesh.vectors, numpy.array([
         [[1, 0, 0], [0, 1, 0], [0, 0, 0]],
         [[0, 1, 0], [1, 0, 0], [1, 1, 0]],
         [[0, 1, 1], [0, 1, 0], [1, 1, 1]],
         [[1, 1, 0], [0, 1, 0], [1, 1, 1]],
         [[0, 0, 1], [0, 1, 1], [0, 1, 0]],
         [[0, 0, 1], [0, 0, 0], [0, 1, 0]],
-    ])).all()
+    ]), atol=1e-07)
 
 
 def test_rotation_over_point():
@@ -127,13 +129,13 @@ def test_no_rotation():
 
     # Rotate by 0 degrees
     mesh.rotate([0.5, 0.0, 0.0], math.radians(0))
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
     # Use a zero rotation matrix
     mesh.rotate([0.0, 0.0, 0.0], math.radians(90))
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
 
 def test_no_translation():
@@ -144,13 +146,13 @@ def test_no_translation():
                                       [0, 0, 1]])
 
     mesh = Mesh(data, remove_empty_areas=False)
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
     # Translate mesh with a zero vector
     mesh.translate([0.0, 0.0, 0.0])
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
 
 def test_translation():
@@ -161,13 +163,13 @@ def test_translation():
                                       [0, 0, 1]])
 
     mesh = Mesh(data, remove_empty_areas=False)
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
     # Translate mesh with vector [1, 2, 3]
     mesh.translate([1.0, 2.0, 3.0])
-    assert (mesh.vectors == numpy.array([
-        [[1, 3, 4], [2, 2, 4], [1, 2, 4]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[1, 3, 4], [2, 2, 4], [1, 2, 4]]]))
 
 
 def test_no_transformation():
@@ -178,14 +180,14 @@ def test_no_transformation():
                                       [0, 0, 1]])
 
     mesh = Mesh(data, remove_empty_areas=False)
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
     # Transform mesh with identity matrix
     mesh.transform(numpy.eye(4))
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
-    assert numpy.all(mesh.areas == 0.5)
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
+    assert numpy.allclose(mesh.areas, 0.5)
 
 
 def test_transformation():
@@ -196,14 +198,14 @@ def test_transformation():
                                       [0, 0, 1]])
 
     mesh = Mesh(data, remove_empty_areas=False)
-    assert (mesh.vectors == numpy.array([
-        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]])).all()
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 1, 1], [1, 0, 1], [0, 0, 1]]]))
 
     # Transform mesh with identity matrix
     tr = numpy.zeros((4, 4))
     tr[0:3, 0:3] = Mesh.rotation_matrix([0, 0, 1], 0.5 * numpy.pi)
     tr[0:3, 3] = [1, 2, 3]
     mesh.transform(tr)
-    assert (mesh.vectors == numpy.array([
-        [[0, 2, 4], [1, 3, 4], [1, 2, 4]]])).all()
-    assert numpy.all(mesh.areas == 0.5)
+    assert numpy.allclose(mesh.vectors, numpy.array([
+        [[0, 2, 4], [1, 3, 4], [1, 2, 4]]]))
+    assert numpy.allclose(mesh.areas, 0.5)


### PR DESCRIPTION
On some platforms, a regular `(a == b).all()` might not work due to float32 not being very precise. In one particular case, we also increase the tolerance for `allclose`, because on ppc64le 3 rotations are enough to divert too much from the mathematically correct result.

We cannot increase the precision, because STL has 32bit floats.

Fixes https://github.com/WoLpH/numpy-stl/issues/78