### PR TITLE
Perform a more thorough check on ASCII STL files.

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -69,7 +69,24 @@ class BaseStl(base.BaseMesh):
 
         name = ''
 
-        if mode in (AUTOMATIC, ASCII) and header.startswith(b('solid')):
+        is_ascii_file = header.startswith(b('solid'))
+        # Even if the 80 char header has "solid" in it, it might be still be a BIN file
+        # A real ASCII file will have "endsolid" in the last line...
+        # but the last line could also have the name identifier string
+        # and we do not know how long that string is (or if there is a max)
+        # The smallest possible STL file is 186 bytes.
+        # So, we'll assume that no one is using ASCII files with identifier strings
+        # longer than 176, read in 176 + 10 ("endsolid", " ", and the EOL), and look
+        # for endsolid.
+        # There _has_ to be a smarter way to do this, but all the other ways
+        # I came up with required reading the whole file. This was the fastest.
+        if is_ascii_file:
+            marker = fh.tell()
+            fh.seek(-186, io.SEEK_END)
+            tail = fh.read().lower()
+            is_ascii_file = tail.find(b('endsolid')) != -1
+            fh.seek(marker)
+        if mode in (AUTOMATIC, ASCII) and is_ascii_file:
             try:
                 name, data = cls._load_ascii(
                     fh, header, speedups=speedups)

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -70,16 +70,16 @@ class BaseStl(base.BaseMesh):
         name = ''
 
         is_ascii_file = header.startswith(b('solid'))
-        # Even if the 80 char header has "solid" in it, it might be still be a BIN file
-        # A real ASCII file will have "endsolid" in the last line...
+        # Even if the 80 char header has "solid" in it, it might be still be a
+        # BIN file. A real ASCII file will have "endsolid" in the last line...
         # but the last line could also have the name identifier string
         # and we do not know how long that string is (or if there is a max)
         # The smallest possible STL file is 186 bytes.
-        # So, we'll assume that no one is using ASCII files with identifier strings
-        # longer than 176, read in 176 + 10 ("endsolid", " ", and the EOL), and look
-        # for endsolid.
+        # So, we'll assume that no one is using ASCII files with identifier
+        # strings longer than 176, read in 176 + 10 ("endsolid", " ", and the
+        # EOL), and look for endsolid.
         # There _has_ to be a smarter way to do this, but all the other ways
-        # I came up with required reading the whole file. This was the fastest.
+        # I came up with required reading the whole file.
         if is_ascii_file:
             marker = fh.tell()
             fh.seek(-186, io.SEEK_END)


### PR DESCRIPTION
I came across a binary STL file which had "solid" in the first 80 characters (can provide on request). This causes the current code to segfault, when it tries to treat a binary STL as an ASCII STL. 

My friends at Lulzbot have a patch that they applied to try to fix this issue:
https://code.alephobjects.com/rNUMPYSTL15d9853f7769a0d3c5318ff75cd7b7481aa1af47

However, their patch causes your test suite to fail (specifically, the ASCII test on long part names), so I investigated further.

The test fails because numpy-stl wants to support ASCII files with long part name identifier strings (the part that comes after "solid"). The STL standard exists, but isn't published anywhere, and I was unable to determine if it specifies a max length for the part name identifier strings. (I've emailed 3D Systems to ask for the standard doc, but I'm not holding my breath).

numpy-stl reads in 80 characters as a header, because the binary specification says the 80 chars are header. The code assumes it only has the 80 character header when operating on binary STLs later, so we can't just read more without breaking lots of things. We also don't know how much more we need to read.

The Lulzbot change adds a search of the first 80 character header for "facet normal", which fixes the crash from my weird binary STL file, but with the test case in your test suite for long part name, "facet normal" does not appear in the first 80 characters, and the test fails (because it thinks the ASCII STL is a binary).

So how can we check for a weird binary STL like mine, which has "solid" in the first 80 chars _AND_ pass the long part name test case?

We know that an ASCII STL file will end with "endsolid" on the last line. But the last line can either look like this:

    endsolid

or

    endsolid part name string of unknown length

And of course, if it is a binary STL file, it will not have "lines", just data.

Here's how I did it.

I found evidence that the smallest possible valid STL file is 186 bytes (https://github.com/WoLpH/numpy-stl/issues/37). So, assuming that no one is using ASCII files with part name identifier strings longer than 176 chars, read in 176 + 10 ("endsolid" +  " " + "176 char ident string" + "\n") chars, and search those chars for "endsolid". If we find it, then it's legit ASCII. If not, it's either binary, an ASCII file with absurdly long part name identifiers, or corrupt.

Since we can seek to the end of the file without reading in the whole file, we can get the "tail" relatively quickly.

This catches the broken binary file, and passes the test suite.

Now, if we discover that there is a max length for this part name identifier string, the problem becomes much easier to solve, but I strongly suspect that:

A) There is not.
B) Even if the standard says there is, there are ASCII STL files which ignore it and have longer than spec strings.

Thankfully, there are very few ASCII STL files in use, and even fewer with very long part name strings, so hopefully the corner case here has become so small that no one will fall in it for a very very very long time (if ever).