### PR TITLE
Revert "converted normals to unit vectors to fix #108"

### DIFF
--- a/stl/base.py
+++ b/stl/base.py
@@ -320,10 +320,6 @@ class BaseMesh(logger.Logged, abc.Mapping):
         if update_areas:
             self.update_areas(normals)
 
-        normal = numpy.linalg.norm(normals, axis=1)
-        non_zero = normal > 0
-        if non_zero.any():
-            normals[non_zero] /= normal[non_zero][:, None]
         self.normals[:] = normals
 
     def update_min(self):

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -50,8 +50,9 @@ def test_units_3d():
     mesh.update_units()
 
     assert (mesh.areas - 2 ** .5) < 0.0001
-    assert numpy.allclose(mesh.normals, [0.0, -0.70710677, 0.70710677])
-    assert numpy.allclose(mesh.units[0], [0.0, -0.5, 0.5])
+    assert numpy.allclose(mesh.normals, [0.0, -1.0, 1.0])
+    assert numpy.allclose(mesh.units[0], [0.0, -0.70710677, 0.70710677])
+    assert numpy.allclose(numpy.linalg.norm(mesh.units, axis=-1), 1)
 
 
 def test_duplicate_polygons():


### PR DESCRIPTION
This reverts commit dcbe8cd162e9312b7d80ac4e1ff557af576cd996 which caused `Mesh.units` to no longer be unit-vectors (i.e. have magnitude of 1.0). Fixes #142.

It's not a true revert as you've made further changes since which caused minor merge conflicts. I've hopefully preserved your further changes. 
