### PR TITLE
add gitattributes file to force CRLF line endings for dos.stl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# force CRLF line endings for dos test file
+tests/stl_tests/dos.stl text eol=crlf
+


### PR DESCRIPTION
The most recent release falls short of 100% test coverage, because dos.stl doesn't have CRLF line endings. This should fix the problem.