### PR TITLE
Drop Python 2 and update mpl examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.rst
+++ b/README.rst
@@ -193,7 +193,7 @@ Modifying Mesh objects
 
     # Create a new plot
     figure = pyplot.figure()
-    axes = mplot3d.Axes3D(figure)
+    axes = figure.add_subplot(projection='3d')
 
     # Render the cube faces
     for m in meshes:
@@ -264,7 +264,7 @@ Extending Mesh objects
 
     # Create a new plot
     figure = pyplot.figure()
-    axes = mplot3d.Axes3D(figure)
+    axes = figure.add_subplot(projection='3d')
 
     # Render the cube
     axes.add_collection3d(mplot3d.art3d.Poly3DCollection(cube.vectors))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,14 @@
-environment:
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  # CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+image:
+  - Visual Studio 2019
 
-  global:
-    PYTHON: "C:\\Python38-x64\\python.exe"
+environment:
   matrix:
   - TOXENV: py36
   - TOXENV: py37
   - TOXENV: py38
-  # not yet available on appveyor
+  # Does not work because of str of py.path
   # - TOXENV: py39
+  # - TOXENV: py310
 
 install:
   # Download setup scripts and unzip
@@ -28,20 +25,20 @@ install:
   # - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
   # Check that we have the expected version and architecture for Python
-  - "%PYTHON% --version"
-  - "%PYTHON% -c \"import struct; print(struct.calcsize('P') * 8)\""
+  - py --version
+  - py -c "import struct; print(struct.calcsize('P') * 8)"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 before_test:
-  - "%PYTHON% -m pip install tox numpy cython wheel"
+  - py -m pip install tox numpy cython wheel
 
 test_script:
-  - "%PYTHON% -m tox -e %TOXENV%"
+  - "py -m tox -e %TOXENV%"
 
 after_test:
-  - "%PYTHON% setup.py build_ext --inplace"
-  - "%PYTHON% setup.py sdist bdist_wheel"
+  - py setup.py build_ext --inplace
+  - py setup.py sdist bdist_wheel
   - ps: "ls dist"
 
 artifacts:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import warnings
@@ -39,22 +37,21 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-if sys.version_info.major == 2 or sys.platform.lower() != 'win32':
-    try:
-        import numpy
-        from Cython import Build
+try:
+    import numpy
+    from Cython import Build
 
-        setup_kwargs['ext_modules'] = Build.cythonize([
-            extension.Extension(
-                'stl._speedups',
-                ['stl/_speedups.pyx'],
-                include_dirs=[numpy.get_include()],
-            ),
-        ])
-    except ImportError:
-        error('WARNING',
-              'Cython and Numpy is required for building extension.',
-              'Falling back to pure Python implementation.')
+    setup_kwargs['ext_modules'] = Build.cythonize([
+        extension.Extension(
+            'stl._speedups',
+            ['stl/_speedups.pyx'],
+            include_dirs=[numpy.get_include()],
+        ),
+    ])
+except ImportError:
+    error('WARNING',
+          'Cython and Numpy is required for building extension.',
+          'Falling back to pure Python implementation.')
 
 # To prevent importing about and thereby breaking the coverage info we use this
 # exec hack
@@ -75,12 +72,6 @@ install_requires = [
     'python-utils>=1.6.2',
 ]
 
-try:
-    import enum
-    assert enum
-except ImportError:
-    install_requires.append('enum34')
-
 
 tests_require = ['pytest']
 
@@ -100,6 +91,7 @@ class BuildExt(build_ext):
 
 if __name__ == '__main__':
     setup(
+        python_requires='>3.6.0',
         name=about['__package_name__'],
         version=about['__version__'],
         author=about['__author__'],
@@ -125,13 +117,12 @@ if __name__ == '__main__':
             'Operating System :: OS Independent',
             'Natural Language :: English',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Topic :: Software Development :: Libraries :: Python Modules',
         ],
         install_requires=install_requires,

--- a/stl/base.py
+++ b/stl/base.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import enum
 import math
 import numpy
@@ -11,7 +9,6 @@ except ImportError:  # pragma: no cover
 
 from python_utils import logger
 
-from .utils import s
 
 #: When removing empty areas, remove areas that are smaller than this
 AREA_SIZE_THRESHOLD = 0
@@ -170,9 +167,9 @@ class BaseMesh(logger.Logged, abc.Mapping):
     #: - vectors: :func:`numpy.float32`, `(3, 3)`
     #: - attr: :func:`numpy.uint16`, `(1, )`
     dtype = numpy.dtype([
-        (s('normals'), numpy.float32, (3, )),
-        (s('vectors'), numpy.float32, (3, 3)),
-        (s('attr'), numpy.uint16, (1, )),
+        ('normals', numpy.float32, (3, )),
+        ('vectors', numpy.float32, (3, 3)),
+        ('attr', numpy.uint16, (1, )),
     ])
     dtype = dtype.newbyteorder('<')  # Even on big endian arches, use little e.
 

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import io
 import os
 import enum
@@ -11,7 +8,6 @@ import datetime
 from . import base
 from . import __about__ as metadata
 from .utils import b
-from .utils import s
 
 try:
     from . import _speedups
@@ -106,7 +102,7 @@ class BaseStl(base.BaseMesh):
         if len(count_data) != COUNT_SIZE:
             count = 0
         else:
-            count, = struct.unpack(s('<i'), b(count_data))
+            count, = struct.unpack('<i', b(count_data))
         # raise RuntimeError()
         assert count < MAX_COUNT, ('File too large, got %d triangles which '
                                    'exceeds the maximum of %d') % (
@@ -333,7 +329,7 @@ class BaseStl(base.BaseMesh):
 
     def _write_binary(self, fh, name):
         header = self.get_header(name)
-        packed = struct.pack(s('<i'), self.data.size)
+        packed = struct.pack('<i', self.data.size)
 
         if isinstance(fh, io.TextIOWrapper):  # pragma: no cover
             packed = str(packed)

--- a/stl/utils.py
+++ b/stl/utils.py
@@ -1,24 +1,6 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-import sys
-
-
-IS_PYTHON2 = (sys.version_info[0] == 2)
-
-
 def b(s, encoding='ascii', errors='replace'):  # pragma: no cover
-    if IS_PYTHON2:
-        return bytes(s)
-    else:
-        if isinstance(s, str):
-            return bytes(s, encoding, errors)
-        else:
-            return s
-        # return bytes(s, encoding, errors)
-
-
-def s(s):  # pragma: no cover
-    if IS_PYTHON2:
-        return bytes(s)
+    if isinstance(s, str):
+        return bytes(s, encoding, errors)
     else:
         return s
+    # return bytes(s, encoding, errors)


### PR DESCRIPTION
Six things (in the order I did them, one lead to another, sort of):

1. Update the rest of the mpl-examples (Axes3D does no longer automatically add itself to a figure).
2. Update supported versions based on the versions tested for
3. Drop Python 2 support
4. ~Test 3.9 and 3.10 on AppVeyor~ Doesn't work because of different `str` of temporary directory(?).
5. Update checkout and setup-python versions for GitHub
6. Cythonize on Windows as well.

~One should possibly also remove all instances of the `s` function, but not done.~