### PR TITLE
Debug tuple print of np.float

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -319,11 +319,11 @@ class BaseStl(base.BaseMesh):
 
             for row in self.data:
                 vectors = row['vectors']
-                p('facet normal %r %r %r' % tuple(row['normals']), file=fh)
+                p('facet normal %r %r %r' % tuple(row['normals'].tolist()), file=fh)
                 p('  outer loop', file=fh)
-                p('    vertex %r %r %r' % tuple(vectors[0]), file=fh)
-                p('    vertex %r %r %r' % tuple(vectors[1]), file=fh)
-                p('    vertex %r %r %r' % tuple(vectors[2]), file=fh)
+                p('    vertex %r %r %r' % tuple(vectors[0].tolist()), file=fh)
+                p('    vertex %r %r %r' % tuple(vectors[1].tolist()), file=fh)
+                p('    vertex %r %r %r' % tuple(vectors[2].tolist()), file=fh)
                 p('  endloop', file=fh)
                 p('endfacet', file=fh)
 


### PR DESCRIPTION
Debug https://github.com/wolph/numpy-stl/issues/223

With numpy>=2.0.0, tuple(vectors[0]) returns the type of the number (eg: np.float64()) instead of the number.

Adding .tolist() to the vector converts the vector to a python list and could be printed.

Work also with numpy <2.0.0