### PR TITLE
Add exact argument to check() function in get_mass_properties_with_density()

### DIFF
--- a/stl/base.py
+++ b/stl/base.py
@@ -655,7 +655,7 @@ class BaseMesh(logger.Logged, abc.Mapping):
 
     def get_mass_properties_with_density(self, density):
         # add density for mesh,density unit kg/m3 when mesh is unit is m
-        self.check()
+        self.check(True)
 
         def subexpression(x):
             w0, w1, w2 = x[:, 0], x[:, 1], x[:, 2]


### PR DESCRIPTION
Similar to the get_mass_properties() method, the get_mass_properties_with_density() method executes a check() which returns a warning due to using the previous approximate method.

This PR adds a True argument to check() in get_mass_properties_with_density() to remove warning.