### PR TITLE
Correctly handle object name in bytearray data

### DIFF
--- a/stl/stl.py
+++ b/stl/stl.py
@@ -311,9 +311,9 @@ class BaseStl(base.BaseMesh):
         else:
 
             def p(s, file):
-                file.write(b(f'{s}\n'))
+                file.write(b(s) + b'\n')
 
-            p(f'solid {name}', file=fh)
+            p(b'solid ' + b(name), file=fh)
 
             for row in self.data:
                 # Explicitly convert each component to standard float for
@@ -343,7 +343,7 @@ class BaseStl(base.BaseMesh):
                 p('  endloop', file=fh)
                 p('endfacet', file=fh)
 
-            p(f'endsolid {name}', file=fh)
+            p(b'endsolid ' + b(name), file=fh)
 
     def get_header(self, name):
         # Format the header


### PR DESCRIPTION
The STL data may come as text or bytearray depending on the source.

The STL output is using string formatting to output numbers, and later converts the formatted numbers to bytearray to write out.

This does not work for the object name when it comes as byte array. Wehn formatted as string the extra b'' is added around it.

Change the p() functio so that it can accept a byte array, and pass in the name as byte array. Convert the name to byte array before passing it to p() in the case it's text.

This avoids the superfluous conversion.

Fixes: #233