### PR TITLE
Fix verified code-scan findings: parser corruption, CLI pipes, stale caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [master, develop]
   pull_request:
   workflow_dispatch:
+  # Allows publish.yml to run the full test suite as a release gate.
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -61,7 +63,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [test, speedups]
+    needs: [test, speedups, docs]
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -117,3 +119,9 @@ jobs:
         run: tox -e docs
       - name: Run docs examples
         run: tox -e docs-examples
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-docs-examples
+          path: .tox/.coverage.*
+          include-hidden-files: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,6 +59,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
       - 'v*'
 
 jobs:
+  # Tag pushes do not trigger ci.yml on their own; run the full test
+  # suite here so nothing reaches PyPI without passing tests.
+  test:
+    uses: ./.github/workflows/ci.yml
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -22,7 +27,7 @@ jobs:
           path: dist/
 
   publish:
-    needs: build
+    needs: [test, build]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Binary STL triangle count is now read and written as the unsigned 32-bit
+  integer the spec requires; counts with the high bit set no longer slip past
+  the size check and silently read the whole file
+- The `stl`, `stl2ascii` and `stl2bin` commands work with piped stdin/stdout
+  again: the std stream defaults now use the underlying binary buffers, and
+  non-seekable streams are buffered so format auto-detection can rewind
+- ASCII STL output uses `{:.9g}` formatting: float32 values round-trip
+  exactly instead of values below 5e-7 being flattened to `0.000000`
+- `save()` no longer swallows `OSError`s; write failures (disk full, broken
+  pipe) propagate instead of silently producing truncated output
+- `transform()` now rotates the stored normals along with the vertices
+- `translate()`, `transform()` and `rotate_using_matrix()` invalidate the
+  cached `min_`/`max_` bounding box
+- `remove_duplicate_polygons` compares full triangles instead of per-axis
+  vertex sums; distinct triangles with equal sums are no longer dropped
+- PLY reader: elements declared before `vertex` are skipped instead of being
+  consumed as vertex data; scalar and extra list face properties around the
+  vertex index list are consumed correctly; out-of-range and negative face
+  indices raise `ValueError` instead of crashing or wrapping around silently
+- PLY reader: vertex elements with list properties raise a descriptive
+  `ValueError` instead of `KeyError: 'list'`
+- 3MF loader raises descriptive `ValueError`s for missing vertex/triangle
+  attributes and out-of-range vertex indices
+- The pure-Python ASCII reader no longer hits `RecursionError` on files with
+  long runs of blank lines
+- `Mesh.from_file()` on an empty file raises a descriptive `ValueError`
+  instead of `TypeError`
+- `save()`/`load()` accept plain ints for `mode` and validate them as
+  `Mode` values
+- Speedups are disabled automatically on non-seekable streams for both
+  reading and writing (the C extension requires seekable files)
+
+### Changed
+- `get_mass_properties()` docs no longer claim a `RuntimeError` is raised
+  for open meshes; the actual behavior (warning + unreliable values) is
+  documented
+- Publishing to PyPI is gated on the full CI test suite
+- numpy dependency declares the tested lower bound (`numpy>=1.24`)
+
 ## [3.2.0] - 2024-11-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "numpy",
+    # np.fromiter with a structured dtype needs numpy>=1.23; 1.24 is
+    # the oldest version in the test matrix.
+    "numpy>=1.24",
     "python-utils>=3.4.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     # the oldest version in the test matrix.
     "numpy>=1.24",
     "python-utils>=3.4.5",
+    # Already transitive via python-utils; declared because stl.stl
+    # imports assert_never at runtime.
+    "typing_extensions>=4.1",
 ]
 
 [project.urls]

--- a/stl/base.py
+++ b/stl/base.py
@@ -445,17 +445,17 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
             # least the originals
             return data[np.sort(idx[np.concatenate(([True], diff))])]
         elif value is RemoveDuplicates.ALL:
-            # We need to return both items of the shifted diff
+            # A polygon is fully unique when it differs from both its
+            # predecessor (diff_a) and its successor (diff_b) in the
+            # sorted order.
             diff_a: _bool_1d = np.concatenate(([True], diff))
             diff_b: _bool_1d = np.concatenate((diff, [True]))
-            diff = np.concatenate((diff, [False]))
 
-            # Combine both unique lists
             filtered_data: _data_1d = data[np.sort(idx[diff_a & diff_b])]
             if len(filtered_data) <= len(data) / 2:
                 return data[np.sort(idx[diff_a])]
             else:
-                return data[np.sort(idx[diff])]
+                return filtered_data
         else:
             return data
 

--- a/stl/base.py
+++ b/stl/base.py
@@ -421,9 +421,17 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
 
         Returns:
             Filtered mesh data array.
+
+        Note:
+            ``ALL`` has a safety fallback: when removing every
+            duplicated polygon would drop half the mesh or more, a
+            single copy of each duplicate is kept instead (the
+            ``SINGLE`` behavior).
         """
         value = RemoveDuplicates.map(value)
-        polygons: _f32_2d = data['vectors'].sum(axis=1)
+        # Compare the full triangles; a lossy key such as the per-axis
+        # vertex sum would treat distinct triangles as duplicates.
+        polygons: _f32_2d = data['vectors'].reshape(len(data), 9)
         # Get a sorted list of indices
         idx: _intp_1d = np.lexsort(polygons.T)
         # Get the indices of all different indices
@@ -525,6 +533,16 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
         """Refresh the cached bounding box maximum."""
         self._max = self.vectors.max(axis=(0, 1))
 
+    def _invalidate_bounds(self) -> None:
+        """Drop cached bounding box values after vertex mutations.
+
+        The :attr:`min_` / :attr:`max_` properties lazily recompute on
+        the next access.
+        """
+        for attribute in ('_min', '_max'):
+            if hasattr(self, attribute):
+                delattr(self, attribute)
+
     def update_areas(self, normals: '_f32_2d | None' = None) -> None:
         """Refresh the cached per-triangle areas.
 
@@ -562,7 +580,7 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
         """
         return self.is_closed(exact=exact)
 
-    def is_closed(self, exact: bool = False) -> bool:  # pragma: no cover
+    def is_closed(self, exact: bool = False) -> bool:
         """Check whether the mesh is watertight.
 
         A closed mesh has every edge shared by exactly two
@@ -645,9 +663,6 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
             - **inertia** -- Inertia tensor as (3, 3) array
               expressed at the COG.
 
-        Raises:
-            RuntimeError: If the mesh is not closed.
-
         Example:
             >>> from stl import mesh
             >>> m = mesh.Mesh.from_file('tests/stl_binary/HalfDonut.stl')
@@ -656,9 +671,11 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
             True
 
         Warning:
-            This method calls ``check(exact=True)``
-            internally. If the mesh is not watertight,
-            a ``RuntimeError`` is raised. Use
+            These values are only meaningful for closed
+            (watertight) meshes. This method checks via
+            ``check(exact=True)`` and logs a warning for
+            open meshes, but still computes and returns
+            the (then unreliable) values. Use
             :meth:`is_closed` to verify beforehand.
         """
         self.check(True)
@@ -870,6 +887,8 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
         for i in range(3):
             self.vectors[:, i] = _rotate(self.vectors[:, i])
 
+        self._invalidate_bounds()
+
     def translate(self, translation: '_ToTranslation') -> None:
         """Translate (move) the mesh.
 
@@ -893,6 +912,7 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
         self.x += translation[0]
         self.y += translation[1]
         self.z += translation[2]
+        self._invalidate_bounds()
 
     def transform(self, matrix: '_f32_2d | _f64_2d') -> None:
         """Apply a 4x4 transformation matrix.
@@ -915,9 +935,13 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
         assert unit_det_rotation, 'Rotation matrix has not a unit determinant'
         for i in range(3):
             self.vectors[:, i] = np.dot(rotation, self.vectors[:, i].T).T
+        # Rotate the stored normals along with the geometry; for a
+        # rotation matrix the inverse transpose equals the matrix itself.
+        self.normals[:] = np.dot(rotation, self.normals.T).T
         self.x += matrix[0, 3]
         self.y += matrix[1, 3]
         self.z += matrix[2, 3]
+        self._invalidate_bounds()
 
     @property
     def min_(self) -> _f32_1d:
@@ -1100,8 +1124,12 @@ class BaseMesh(logger.Logged, abc.Mapping['_ToIndices', np.ndarray]):
             - **inertia** -- Inertia tensor as (3, 3)
               array.
 
-        Raises:
-            RuntimeError: If the mesh is not closed.
+        Warning:
+            These values are only meaningful for closed
+            (watertight) meshes. This method checks via
+            ``check(exact=True)`` and logs a warning for
+            open meshes, but still computes and returns
+            the (then unreliable) values.
         """
         self.check(True)
 

--- a/stl/main.py
+++ b/stl/main.py
@@ -7,18 +7,20 @@ from . import stl
 
 def _get_parser(description: str) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=description)
+    # The std stream defaults use the underlying binary buffers: STL
+    # data is binary and the text wrappers would corrupt it (or raise).
     parser.add_argument(
         'infile',
         nargs='?',
         type=argparse.FileType('rb'),
-        default=sys.stdin,
+        default=sys.stdin.buffer,
         help='STL file to read',
     )
     parser.add_argument(
         'outfile',
         nargs='?',
         type=argparse.FileType('wb'),
-        default=sys.stdout,
+        default=sys.stdout.buffer,
         help='STL file to write',
     )
     parser.add_argument('--name', nargs='?', help='Name of the mesh')

--- a/stl/ply.py
+++ b/stl/ply.py
@@ -183,6 +183,36 @@ def _find_xyz_indices(
     return xi, yi, zi
 
 
+def _element_row_size(element: _Element) -> int:
+    """Return the fixed byte size of one binary row of an element.
+
+    Raises:
+        ValueError: If the element has list properties; their rows
+            have no fixed binary size.
+    """
+    row_size = 0
+    for prop in element.properties:
+        if prop.is_list:
+            raise ValueError(
+                f'Element {element.name!r} has list properties; '
+                'its rows have no fixed binary size'
+            )
+        row_size += _PLY_TYPES[prop.type_name][2]
+    return row_size
+
+
+def _find_face_list_index(face_elem: _Element) -> int:
+    """Return the position of the first list property of a face.
+
+    Raises:
+        ValueError: If the face element has no list property.
+    """
+    for i, prop in enumerate(face_elem.properties):
+        if prop.is_list:
+            return i
+    raise ValueError('Face element has no list property')
+
+
 def _read_ascii(
     fh: IO[bytes],
     elements: list[_Element],
@@ -195,6 +225,9 @@ def _read_ascii(
     """
     vertex_elem, face_elem = _find_elements(elements)
     xi, yi, zi = _find_xyz_indices(vertex_elem)
+    # The vertex index list may be preceded by scalar face properties;
+    # its count value sits at this field offset.
+    list_index = _find_face_list_index(face_elem)
 
     # Read all elements in order
     vertices = np.empty((vertex_elem.count, 3), dtype=np.float32)
@@ -217,10 +250,8 @@ def _read_ascii(
                     float(parts[zi]),
                 ]
             elif elem is face_elem:
-                # First value is the vertex count,
-                # followed by vertex indices
-                n = int(parts[0])
-                indices = [int(parts[j + 1]) for j in range(n)]
+                n = int(parts[list_index])
+                indices = [int(parts[list_index + 1 + j]) for j in range(n)]
                 faces.append(indices)
             # Other elements: skip (already consumed)
 
@@ -256,29 +287,35 @@ def _read_binary_faces(
     face_elem: _Element,
     endian: str,
 ) -> list[list[int]]:
-    """Read binary face data."""
-    list_prop = None
-    for prop in face_elem.properties:
-        if prop.is_list:
-            list_prop = prop
-            break
-    if list_prop is None:
-        raise ValueError('Face element has no list property')
+    """Read binary face data.
 
-    count_fmt_char, _, count_size = _PLY_TYPES[list_prop.count_type]
-    idx_fmt_char, _, idx_size = _PLY_TYPES[list_prop.item_type]
-    count_fmt = endian + count_fmt_char
+    Every property of each face row is consumed in declared order;
+    scalar properties and extra list properties around the vertex
+    index list are read and discarded.
+    """
+    list_prop = face_elem.properties[_find_face_list_index(face_elem)]
 
     faces: list[list[int]] = []
     for _ in range(face_elem.count):
-        count_raw = fh.read(count_size)
-        if len(count_raw) != count_size:
-            raise ValueError('Unexpected EOF reading face')
-        n = struct.unpack(count_fmt, count_raw)[0]
-        idx_raw = fh.read(n * idx_size)
-        if len(idx_raw) != n * idx_size:
-            raise ValueError('Unexpected EOF reading face indices')
-        indices = list(struct.unpack(endian + idx_fmt_char * n, idx_raw))
+        indices: list[int] = []
+        for prop in face_elem.properties:
+            if prop.is_list:
+                count_fmt_char, _, count_size = _PLY_TYPES[prop.count_type]
+                item_fmt_char, _, item_size = _PLY_TYPES[prop.item_type]
+                count_raw = fh.read(count_size)
+                if len(count_raw) != count_size:
+                    raise ValueError('Unexpected EOF reading face')
+                n = struct.unpack(endian + count_fmt_char, count_raw)[0]
+                item_raw = fh.read(n * item_size)
+                if len(item_raw) != n * item_size:
+                    raise ValueError('Unexpected EOF reading face indices')
+                if prop is list_prop:
+                    indices = list(
+                        struct.unpack(endian + item_fmt_char * n, item_raw)
+                    )
+            else:
+                # Skip scalar properties around the index list.
+                fh.read(_PLY_TYPES[prop.type_name][2])
         faces.append(indices)
     return faces
 
@@ -299,15 +336,7 @@ def _skip_binary_elements(
             break
         if not found_vertex:
             continue
-        row_size = 0
-        for prop in elem.properties:
-            if prop.is_list:
-                raise ValueError(
-                    f'Cannot skip element with list properties: {elem.name}'
-                )
-            _, _, size = _PLY_TYPES[prop.type_name]
-            row_size += size
-        fh.read(elem.count * row_size)
+        fh.read(elem.count * _element_row_size(elem))
 
 
 def _read_binary(
@@ -325,10 +354,13 @@ def _read_binary(
     vertex_elem, face_elem = _find_elements(elements)
     xi, yi, zi = _find_xyz_indices(vertex_elem)
 
+    # Skip elements declared before the vertex element; their data
+    # precedes the vertex data in the binary stream.
+    for elem in elements[: elements.index(vertex_elem)]:
+        fh.read(elem.count * _element_row_size(elem))
+
     # Compute vertex row size for bulk read.
-    vertex_size = sum(
-        _PLY_TYPES[p.type_name][2] for p in vertex_elem.properties
-    )
+    vertex_size = _element_row_size(vertex_elem)
     n_verts = vertex_elem.count
     raw = fh.read(n_verts * vertex_size)
     if len(raw) != n_verts * vertex_size:
@@ -378,8 +410,16 @@ def _build_mesh_data(
         Structured 1-D numpy array with the mesh dtype.
     """
     count = len(triangles)
+    n_vertices = len(vertices)
     data = np.zeros(count, dtype=mesh_dtype)
     for i, (a, b, c) in enumerate(triangles):
+        for index in (a, b, c):
+            # Negative indices must not wrap around silently.
+            if not 0 <= index < n_vertices:
+                raise ValueError(
+                    f'Face {i} references vertex index {index}, which is '
+                    f'out of range (0..{n_vertices - 1})'
+                )
         data['vectors'][i][0] = vertices[a]
         data['vectors'][i][1] = vertices[b]
         data['vectors'][i][2] = vertices[c]

--- a/stl/ply.py
+++ b/stl/ply.py
@@ -201,6 +201,18 @@ def _element_row_size(element: _Element) -> int:
     return row_size
 
 
+def _skip_element_rows(fh: IO[bytes], element: _Element) -> None:
+    """Skip all binary rows of a fixed-size element, validating EOF.
+
+    Raises:
+        ValueError: If the element has list properties or the file
+            ends before all rows are consumed.
+    """
+    size = element.count * _element_row_size(element)
+    if len(fh.read(size)) != size:
+        raise ValueError(f'Unexpected EOF skipping element {element.name!r}')
+
+
 def _find_face_list_index(face_elem: _Element) -> int:
     """Return the position of the first list property of a face.
 
@@ -315,7 +327,11 @@ def _read_binary_faces(
                     )
             else:
                 # Skip scalar properties around the index list.
-                fh.read(_PLY_TYPES[prop.type_name][2])
+                scalar_size = _PLY_TYPES[prop.type_name][2]
+                if len(fh.read(scalar_size)) != scalar_size:
+                    raise ValueError(
+                        'Unexpected EOF reading face scalar property'
+                    )
         faces.append(indices)
     return faces
 
@@ -336,7 +352,7 @@ def _skip_binary_elements(
             break
         if not found_vertex:
             continue
-        fh.read(elem.count * _element_row_size(elem))
+        _skip_element_rows(fh, elem)
 
 
 def _read_binary(
@@ -357,7 +373,7 @@ def _read_binary(
     # Skip elements declared before the vertex element; their data
     # precedes the vertex data in the binary stream.
     for elem in elements[: elements.index(vertex_elem)]:
-        fh.read(elem.count * _element_row_size(elem))
+        _skip_element_rows(fh, elem)
 
     # Compute vertex row size for bulk read.
     vertex_size = _element_row_size(vertex_elem)

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     @type_check_only
     class _StatefulWriter(Writer[Buffer], Protocol):
         def tell(self) -> int: ...
+        def seekable(self) -> bool: ...
 
 
 class Mode(enum.IntEnum):
@@ -75,12 +76,45 @@ MAX_COUNT: float = 1e8
 HEADER_FORMAT: str = '{package_name} ({version}) {now} {name}'
 
 
+def _ensure_seekable(fh: IO[Any]) -> IO[Any]:
+    """Return a seekable handle, buffering pipe-like streams fully.
+
+    Format auto-detection and multi-solid parsing need to seek, which
+    streams such as stdin do not support.
+    """
+    if fh.seekable():
+        return fh
+    return io.BytesIO(b(fh.read()))
+
+
+def _3mf_index(
+    attributes: dict[str, int],
+    key: str,
+    vertices: 'list[list[float]]',
+) -> int:
+    """Validate and return a triangle vertex index from a 3MF file."""
+    try:
+        index: int = attributes[key]
+    except KeyError as exception:
+        raise ValueError(
+            f'Triangle is missing attribute {key!r}'
+        ) from exception
+
+    if not 0 <= index < len(vertices):
+        raise ValueError(
+            f'Triangle vertex index {key}={index} is out of range '
+            f'(0..{len(vertices) - 1})'
+        )
+
+    return index
+
+
 class BaseStl(base.BaseMesh):
     @classmethod
     def load(
         cls,
         fh: IO[Any],
-        mode: Mode = AUTOMATIC,
+        mode: 'Mode | int' = AUTOMATIC,
         speedups: bool = True,
     ) -> 'tuple[bytes, _data_1d] | Any':
         """Load mesh data from an open STL file handle.
@@ -91,14 +125,21 @@ class BaseStl(base.BaseMesh):
         Args:
             fh: Open binary file handle.
             mode: Force a specific format or use
-                :attr:`Mode.AUTOMATIC` (default).
+                :attr:`Mode.AUTOMATIC` (default). Plain
+                ints are accepted and converted to
+                :class:`Mode`.
             speedups: Use Cython speedups for ASCII
                 parsing. Defaults to True.
 
         Returns:
             A (name, data) tuple, or None if the file
             is empty.
+
+        Raises:
+            ValueError: If ``mode`` is not a valid
+                :class:`Mode` value.
         """
+        mode = Mode(mode)
         header = fh.read(HEADER_SIZE)
         if not header:
             return None
@@ -152,8 +193,10 @@ class BaseStl(base.BaseMesh):
         if len(count_data) != COUNT_SIZE:
             count = 0
         else:
-            (count,) = struct.unpack('<i', b(count_data))
-        # raise RuntimeError()
+            # The triangle count is an unsigned 32-bit integer per the
+            # STL specification; '<i' would turn large counts negative
+            # and slip past the size check below.
+            (count,) = struct.unpack('<I', b(count_data))
         assert count < MAX_COUNT, (
             f'File too large, got {count} triangles which '
             f'exceeds the maximum of {MAX_COUNT}'
@@ -202,22 +245,27 @@ class BaseStl(base.BaseMesh):
         def get(prefix: '_Name' = '') -> 'bytes | list[float]':
             prefix = b(prefix).lower()
 
-            if lines:
-                raw_line = lines.pop(0)
-            else:
-                raise RuntimeError(recoverable[0], 'Unable to find more lines')
+            # Skip blank lines with a loop; recursing per line would
+            # exhaust the stack on files with long blank-line runs.
+            line = b('')
+            raw_line = b('')
+            while not line:
+                if lines:
+                    raw_line = lines.pop(0)
+                else:
+                    raise RuntimeError(
+                        recoverable[0], 'Unable to find more lines'
+                    )
 
-            if not lines:
-                recoverable[0] = False
+                if not lines:
+                    recoverable[0] = False
 
-                # Read more lines and make sure we prepend any old data
-                lines[:] = b(fh.read(BUFFER_SIZE)).split(b'\n')
-                raw_line += lines.pop(0)
+                    # Read more lines and make sure we prepend any old data
+                    lines[:] = b(fh.read(BUFFER_SIZE)).split(b'\n')
+                    raw_line += lines.pop(0)
 
-            raw_line = raw_line.strip()
-            line = raw_line.lower()
-            if line == b(''):
-                return get(prefix)
+                raw_line = raw_line.strip()
+                line = raw_line.lower()
 
             if prefix:
                 if line.startswith(prefix):
@@ -285,9 +333,12 @@ class BaseStl(base.BaseMesh):
         header: bytes,
         speedups: bool = True,
     ) -> tuple[bytes, '_data_1d']:
-        # Speedups does not support non file-based streams
+        # Speedups does not support non file-based streams. Pipes such
+        # as stdin have a file descriptor but cannot seek, which the C
+        # reader requires as well.
         try:
             fh.fileno()
+            speedups = speedups and fh.seekable()
         except io.UnsupportedOperation:
             speedups = False
         if _ascii_read is not None and speedups:
@@ -320,6 +371,8 @@ class BaseStl(base.BaseMesh):
 
         Raises:
             TypeError: If ``fh`` is a text-mode handle.
+            ValueError: If ``mode`` is not a valid
+                :class:`Mode` value.
 
         Example:
             >>> import numpy as np
@@ -335,6 +388,7 @@ class BaseStl(base.BaseMesh):
             handle raises ``TypeError``.
         """
         assert filename, 'Filename is required for the STL headers'
+        mode = Mode(mode)
         if update_normals:
             self.update_normals()
 
@@ -354,10 +408,8 @@ class BaseStl(base.BaseMesh):
                 write = self._write_binary
         elif mode is BINARY:
             write = self._write_binary
-        elif mode is ASCII:
+        else:  # Mode.ASCII
             write = self._write_ascii
-        else:
-            raise ValueError(f'Mode {mode!r} is invalid')
 
         if isinstance(fh, io.TextIOBase):
             # Provide a more helpful error if the user mistakenly
@@ -371,19 +423,18 @@ class BaseStl(base.BaseMesh):
         if not name:
             name = os.path.split(filename)[-1]
 
-        try:
-            if fh:
+        if fh:
+            write(fh, name)
+        else:
+            with open(filename, 'wb') as fh:
                 write(fh, name)
-            else:
-                with open(filename, 'wb') as fh:
-                    write(fh, name)
-        except OSError:  # pragma: no cover
-            pass
 
     def _write_ascii(self, fh: IO[bytes], name: '_Name') -> None:
         try:
             fh.fileno()
-            speedups = self.speedups
+            # The C writer needs a real, seekable file; pipes such as
+            # stdout have a file descriptor but cannot seek.
+            speedups = self.speedups and fh.seekable()
         except io.UnsupportedOperation:
             speedups = False
 
@@ -396,27 +447,32 @@ class BaseStl(base.BaseMesh):
 
             p(b'solid ' + b(name), file=fh)
 
+            # 9 significant digits round-trip any float32 exactly; '{:f}'
+            # (fixed 6 decimals) would silently write tiny values as 0.
             for row in self.data:
                 # Explicitly convert each component to standard float for
                 # normals and vertices to be compatible with numpy 2.x
                 normals = tuple(float(n) for n in row['normals'])
                 vectors = row['vectors']
-                p('facet normal {:f} {:f} {:f}'.format(*normals), file=fh)
+                p(
+                    'facet normal {:.9g} {:.9g} {:.9g}'.format(*normals),
+                    file=fh,
+                )
                 p('  outer loop', file=fh)
                 p(
-                    '    vertex {:f} {:f} {:f}'.format(
+                    '    vertex {:.9g} {:.9g} {:.9g}'.format(
                         *tuple(float(v) for v in vectors[0])
                     ),
                     file=fh,
                 )
                 p(
-                    '    vertex {:f} {:f} {:f}'.format(
+                    '    vertex {:.9g} {:.9g} {:.9g}'.format(
                         *tuple(float(v) for v in vectors[1])
                     ),
                     file=fh,
                 )
                 p(
-                    '    vertex {:f} {:f} {:f}'.format(
+                    '    vertex {:.9g} {:.9g} {:.9g}'.format(
                         *tuple(float(v) for v in vectors[2])
                     ),
                     file=fh,
@@ -452,7 +508,7 @@ class BaseStl(base.BaseMesh):
         name: '_Name',
     ) -> None:
         header = self.get_header(name)
-        packed = struct.pack('<i', self.data.size)
+        packed = struct.pack('<I', self.data.size)
 
         if isinstance(fh, io.TextIOWrapper):  # pragma: no cover
             fh.write(header)
@@ -461,16 +517,18 @@ class BaseStl(base.BaseMesh):
             fh.write(b(header))
             fh.write(b(packed))
 
-        if isinstance(fh, io.BufferedWriter):
-            # Write to a true file.
+        if isinstance(fh, io.BufferedWriter) and fh.seekable():
+            # Write to a true file. numpy's tofile() needs to query the
+            # file position, which fails on pipes such as stdout.
             self.data.tofile(fh)
         else:
-            # Write to a pseudo buffer.
+            # Write to a pseudo buffer (e.g. BytesIO or a pipe).
             cast('_StatefulWriter', fh).write(self.data.data)
 
         # In theory this should no longer be possible but I'll leave it here
-        # anyway...
-        if self.data.size:  # pragma: no cover
+        # anyway... Note that tell() is unavailable on pipes such as
+        # stdout, hence the seekable() guard.
+        if self.data.size and fh.seekable():  # pragma: no cover
             assert fh.tell() > 84, (
                 'numpy silently refused to write our file. Note that writing '
                 'to `StringIO` objects is not supported by `numpy`'
@@ -508,6 +566,9 @@ class BaseStl(base.BaseMesh):
         Returns:
             A new Mesh instance containing the loaded data.
 
+        Raises:
+            ValueError: If the file is empty.
+
         Example:
             >>> from stl import mesh
             >>> m = mesh.Mesh.from_file('tests/stl_binary/HalfDonut.stl')
@@ -522,10 +583,16 @@ class BaseStl(base.BaseMesh):
             streams (e.g., stdin).
         """
         if fh:
-            name, data = cls.load(fh, mode=mode, speedups=speedups)
+            result = cls.load(
+                _ensure_seekable(fh), mode=mode, speedups=speedups
+            )
         else:
             with open(filename, 'rb') as fh:
-                name, data = cls.load(fh, mode=mode, speedups=speedups)
+                result = cls.load(fh, mode=mode, speedups=speedups)
+
+        if result is None:
+            raise ValueError(f'STL file is empty: {filename}')
+        name, data = result
 
         # pyrefly: ignore[bad-return]
         return cls(
@@ -575,6 +642,7 @@ class BaseStl(base.BaseMesh):
             a single solid.
         """
         if fh:
+            fh = _ensure_seekable(fh)
             close = False
         else:
             fh = open(filename, 'rb')  # noqa: SIM115
@@ -701,7 +769,13 @@ class BaseStl(base.BaseMesh):
                                     k: float(v)
                                     for k, v in vertice.attrib.items()
                                 }
-                                vertices.append([a['x'], a['y'], a['z']])
+                                try:
+                                    vertices.append([a['x'], a['y'], a['z']])
+                                except KeyError as exception:
+                                    raise ValueError(
+                                        f'Vertex in {filename} is missing '
+                                        f'attribute {exception}'
+                                    ) from exception
 
                         elif tag.endswith('triangles'):  # pragma: no branch
                             # Map the triangles to the vertices and collect
@@ -712,9 +786,15 @@ class BaseStl(base.BaseMesh):
                                 }
                                 triangles.append(
                                     [
-                                        vertices[a['v1']],
-                                        vertices[a['v2']],
-                                        vertices[a['v3']],
+                                        vertices[
+                                            _3mf_index(a, 'v1', vertices)
+                                        ],
+                                        vertices[
+                                            _3mf_index(a, 'v2', vertices)
+                                        ],
+                                        vertices[
+                                            _3mf_index(a, 'v3', vertices)
+                                        ],
                                     ]
                                 )
 

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -76,13 +76,21 @@ MAX_COUNT: float = 1e8
 HEADER_FORMAT: str = '{package_name} ({version}) {now} {name}'
 
 
-def _ensure_seekable(fh: IO[Any]) -> IO[Any]:
+def _ensure_seekable(fh: IO[Any], mode: Mode = AUTOMATIC) -> IO[Any]:
     """Return a seekable handle, buffering pipe-like streams fully.
 
-    Format auto-detection and multi-solid parsing need to seek, which
-    streams such as stdin do not support.
+    Format auto-detection needs to rewind and the binary loader needs
+    seek/tell, which streams such as stdin do not support. Explicit
+    ASCII parsing streams in bounded chunks and is left untouched to
+    avoid buffering large piped files in memory.
     """
-    if fh.seekable():
+    if mode is ASCII:
+        return fh
+
+    # Duck-typed file-likes may not implement seekable() at all;
+    # treat those like pipes and buffer them.
+    seekable = getattr(fh, 'seekable', None)
+    if seekable is not None and seekable():
         return fh
     return io.BytesIO(b(fh.read()))
 
@@ -335,11 +343,12 @@ class BaseStl(base.BaseMesh):
     ) -> tuple[bytes, '_data_1d']:
         # Speedups does not support non file-based streams. Pipes such
         # as stdin have a file descriptor but cannot seek, which the C
-        # reader requires as well.
+        # reader requires as well. Duck-typed file-likes may implement
+        # neither method, hence the AttributeError.
         try:
             fh.fileno()
             speedups = speedups and fh.seekable()
-        except io.UnsupportedOperation:
+        except (AttributeError, io.UnsupportedOperation):
             speedups = False
         if _ascii_read is not None and speedups:
             return _ascii_read(fh, header)
@@ -433,9 +442,11 @@ class BaseStl(base.BaseMesh):
         try:
             fh.fileno()
             # The C writer needs a real, seekable file; pipes such as
-            # stdout have a file descriptor but cannot seek.
+            # stdout have a file descriptor but cannot seek. Duck-typed
+            # file-likes may implement neither method, hence the
+            # AttributeError.
             speedups = self.speedups and fh.seekable()
-        except io.UnsupportedOperation:
+        except (AttributeError, io.UnsupportedOperation):
             speedups = False
 
         if _ascii_write is not None and speedups:
@@ -582,9 +593,10 @@ class BaseStl(base.BaseMesh):
             automatically disabled for non-seekable
             streams (e.g., stdin).
         """
+        mode = Mode(mode)
         if fh:
             result = cls.load(
-                _ensure_seekable(fh), mode=mode, speedups=speedups
+                _ensure_seekable(fh, mode), mode=mode, speedups=speedups
             )
         else:
             with open(filename, 'rb') as fh:

--- a/stl/stl.py
+++ b/stl/stl.py
@@ -16,6 +16,10 @@ from xml.etree import ElementTree as ET
 
 import numpy as np
 
+# typing.assert_never requires Python 3.11; typing_extensions is a
+# guaranteed runtime dependency via python-utils.
+from typing_extensions import assert_never
+
 from . import (
     __about__ as metadata,
     base,
@@ -184,8 +188,10 @@ class BaseStl(base.BaseMesh):
                 name, data = cls._load_binary(fh, header)
         elif mode is ASCII:
             name, data = cls._load_ascii(fh, header, speedups=speedups)
-        else:
+        elif mode is BINARY:
             name, data = cls._load_binary(fh, header)
+        else:  # pragma: no cover - exhaustiveness guard for new modes
+            assert_never(mode)
 
         return name, data
 
@@ -417,8 +423,10 @@ class BaseStl(base.BaseMesh):
                 write = self._write_binary
         elif mode is BINARY:
             write = self._write_binary
-        else:  # Mode.ASCII
+        elif mode is ASCII:
             write = self._write_ascii
+        else:  # pragma: no cover - exhaustiveness guard for new modes
+            assert_never(mode)
 
         if isinstance(fh, io.TextIOBase):
             # Provide a more helpful error if the user mistakenly

--- a/stl/utils.py
+++ b/stl/utils.py
@@ -2,7 +2,7 @@ def b(
     s: 'str | bytes',
     encoding: str = 'ascii',
     errors: str = 'replace',
-) -> bytes:  # pragma: no cover
+) -> bytes:
     """Encode a string to bytes, passing bytes through.
 
     Args:

--- a/tests/stl_corruption.py
+++ b/tests/stl_corruption.py
@@ -1,5 +1,4 @@
 import struct
-import sys
 
 import numpy as np
 import pytest
@@ -101,9 +100,8 @@ def test_corrupt_ascii_file(tmpdir, speedups):
         fh.seek(40)
         print('####\n' * 100, file=fh)
         fh.seek(0)
-        if speedups and sys.version_info.major != 2:
-            with pytest.raises(AssertionError):
-                mesh.Mesh.from_file(str(tmp_file), fh=fh, speedups=speedups)
+        with pytest.raises(AssertionError):
+            mesh.Mesh.from_file(str(tmp_file), fh=fh, speedups=speedups)
 
     with tmp_file.open('w+') as fh:
         fh.write(_STL_FILE)
@@ -142,8 +140,8 @@ def test_corrupt_binary_file(tmpdir, speedups):
 def test_duplicate_polygons():
     data = np.zeros(3, dtype=mesh.Mesh.dtype)
     data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 1.0]])
-    data['vectors'][0] = np.array([[0, 0, 0], [2, 0, 0], [0, 2, 1.0]])
-    data['vectors'][0] = np.array([[0, 0, 0], [3, 0, 0], [0, 3, 1.0]])
+    data['vectors'][1] = np.array([[0, 0, 0], [2, 0, 0], [0, 2, 1.0]])
+    data['vectors'][2] = np.array([[0, 0, 0], [3, 0, 0], [0, 3, 1.0]])
 
     assert not mesh.Mesh(data, remove_empty_areas=False).check()
     # type: ignore[reportAttributeAccessIssue]

--- a/tests/test_3mf.py
+++ b/tests/test_3mf.py
@@ -1,0 +1,92 @@
+import pathlib
+import zipfile
+
+import numpy as np
+import pytest
+
+from stl import mesh
+
+_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships
+ xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+ <Relationship Target="/3D/3dmodel.model" Id="rel0"
+  Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel"/>
+</Relationships>"""
+
+_MODEL_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+ <resources>
+  <object id="1" type="model">
+   <mesh>
+    <vertices>{vertices}</vertices>
+    <triangles>{triangles}</triangles>
+   </mesh>
+  </object>
+ </resources>
+ <build><item objectid="1"/></build>
+</model>"""
+
+_GOOD_VERTICES = (
+    '<vertex x="0" y="0" z="0"/>'
+    '<vertex x="1" y="0" z="0"/>'
+    '<vertex x="0" y="1" z="0"/>'
+)
+_GOOD_TRIANGLES = '<triangle v1="0" v2="1" v3="2"/>'
+
+
+def _make_3mf(
+    tmp_path: pathlib.Path,
+    vertices: str = _GOOD_VERTICES,
+    triangles: str = _GOOD_TRIANGLES,
+) -> str:
+    path = tmp_path / 'test.3mf'
+    with zipfile.ZipFile(path, 'w') as archive:
+        archive.writestr('_rels/.rels', _RELS)
+        archive.writestr(
+            '3D/3dmodel.model',
+            _MODEL_TEMPLATE.format(vertices=vertices, triangles=triangles),
+        )
+    return str(path)
+
+
+def test_3mf_valid_file(tmp_path):
+    meshes = list(mesh.Mesh.from_3mf_file(_make_3mf(tmp_path)))
+
+    assert len(meshes) == 1
+    assert np.allclose(
+        meshes[0].vectors[0],
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+    )
+
+
+def test_3mf_vertex_missing_coordinate(tmp_path):
+    # Used to crash with a raw KeyError: 'z'.
+    filename = _make_3mf(
+        tmp_path,
+        vertices=(
+            '<vertex x="0" y="0"/>'
+            '<vertex x="1" y="0" z="0"/>'
+            '<vertex x="0" y="1" z="0"/>'
+        ),
+    )
+    with pytest.raises(ValueError, match='z'):
+        list(mesh.Mesh.from_3mf_file(filename))
+
+
+def test_3mf_triangle_missing_index(tmp_path):
+    # Used to crash with a raw KeyError: 'v3'.
+    filename = _make_3mf(tmp_path, triangles='<triangle v1="0" v2="1"/>')
+    with pytest.raises(ValueError, match='v3'):
+        list(mesh.Mesh.from_3mf_file(filename))
+
+
+@pytest.mark.parametrize('bad_index', ['99', '-1'])
+def test_3mf_triangle_index_out_of_range(tmp_path, bad_index):
+    # Out-of-range used to raise a raw IndexError; negative indices
+    # silently wrapped around.
+    filename = _make_3mf(
+        tmp_path,
+        triangles=f'<triangle v1="0" v2="1" v3="{bad_index}"/>',
+    )
+    with pytest.raises(ValueError, match='index'):
+        list(mesh.Mesh.from_3mf_file(filename))

--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -226,6 +226,46 @@ def test_ascii_write_is_lossless_for_tiny_values(speedups):
     assert (round_tripped.vectors == original.vectors).all()
 
 
+class _ChunkOnlyStream(io.RawIOBase):
+    """Non-seekable stream that forbids unbounded (slurp) reads."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buffer = io.BytesIO(data)
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        assert size is not None and size >= 0, 'full slurp not allowed'
+        return self._buffer.read(size)
+
+    def seekable(self) -> bool:
+        return False
+
+
+def test_explicit_ascii_mode_streams_from_pipe(speedups):
+    # With mode=ASCII the pure-Python reader consumes the stream in
+    # bounded chunks; the file must not be buffered into memory whole.
+    content = (
+        b'solid streaming\n'
+        b'facet normal 0 0 1\n'
+        b'  outer loop\n'
+        b'    vertex 0 0 0\n'
+        b'    vertex 1 0 0\n'
+        b'    vertex 0 1 0\n'
+        b'  endloop\n'
+        b'endfacet\n'
+        b'endsolid streaming\n'
+    )
+    loaded = mesh.Mesh.from_file(
+        'stream.stl',
+        fh=_ChunkOnlyStream(content),
+        mode=Mode.ASCII,
+        speedups=False,
+    )
+    assert len(loaded.data) == 1
+
+
 def test_ascii_reader_handles_many_blank_lines(speedups):
     # The blank-line skip used to recurse once per line and hit
     # RecursionError around 1000 consecutive blank lines.

--- a/tests/test_ascii.py
+++ b/tests/test_ascii.py
@@ -203,3 +203,46 @@ def test_ascii_io():
     read = mesh.Mesh.from_file('anonymous.stl', fh=io.BytesIO(fh.getvalue()))
     # Check what comes out is the same as what went in.
     assert np.allclose(mesh_.vectors, read.vectors)
+
+
+def test_ascii_write_is_lossless_for_tiny_values(speedups):
+    # '{:f}' formatting used to flatten |value| < 5e-7 to '0.000000'.
+    # speedups=False throughout: the pure-Python writer is under test
+    # (the external speedups C writer has its own formatting).
+    data = np.zeros(1, dtype=mesh.Mesh.dtype)
+    data['vectors'][0] = np.array(
+        [[1e-10, 5e-8, -2.5e-9], [0, 1, 0], [0, 0, 1]],
+        dtype=np.float32,
+    )
+    original = mesh.Mesh(data, remove_empty_areas=False, speedups=False)
+
+    fh = io.BytesIO()
+    original.save('tiny.stl', fh=fh, mode=Mode.ASCII, update_normals=False)
+    fh.seek(0)
+
+    round_tripped = mesh.Mesh.from_file(
+        'tiny.stl', fh=fh, mode=Mode.ASCII, speedups=False
+    )
+    assert (round_tripped.vectors == original.vectors).all()
+
+
+def test_ascii_reader_handles_many_blank_lines(speedups):
+    # The blank-line skip used to recurse once per line and hit
+    # RecursionError around 1000 consecutive blank lines.
+    content = (
+        b'solid test\n' + b'\n' * 5000 + b'facet normal 0 0 1\n'
+        b'  outer loop\n'
+        b'    vertex 0 0 0\n'
+        b'    vertex 1 0 0\n'
+        b'    vertex 0 1 0\n'
+        b'  endloop\n'
+        b'endfacet\n'
+        b'endsolid test\n'
+    )
+    loaded = mesh.Mesh.from_file(
+        'blank.stl',
+        fh=io.BytesIO(content),
+        mode=Mode.ASCII,
+        speedups=False,
+    )
+    assert len(loaded.data) == 1

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -1,5 +1,6 @@
 import io
 import pathlib
+import struct
 
 import numpy as np
 import pytest
@@ -54,3 +55,67 @@ def test_write_bytes_io(binary_file, mode):
 
 def test_binary_file():
     list(mesh.Mesh.from_multi_file(TESTS_PATH / 'stl_tests' / 'triamid.stl'))
+
+
+def test_binary_count_field_parsed_as_unsigned(speedups):
+    # A count with the high bit set used to be unpacked as a negative
+    # signed int, slip past the MAX_COUNT assertion, and make
+    # np.fromfile(count=-1) silently read the whole file.
+    record = b'\x00' * mesh.Mesh.dtype.itemsize
+    for count in (0xFFFFFFFF, 2**31 + 5):
+        raw = b'#' * 80 + struct.pack('<I', count) + record * 3
+        with pytest.raises(AssertionError, match='too large'):
+            mesh.Mesh.from_file(
+                'huge.stl',
+                fh=io.BytesIO(raw),
+                mode=Mode.BINARY,
+                speedups=speedups,
+            )
+
+
+def test_load_empty_file_raises_value_error(speedups):
+    with pytest.raises(ValueError, match='empty'):
+        mesh.Mesh.from_file('empty.stl', fh=io.BytesIO(b''), speedups=speedups)
+
+
+class _NonSeekableStream(io.RawIOBase):
+    """Minimal non-seekable binary stream, like a pipe."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buffer = io.BytesIO(data)
+
+    def readable(self) -> bool:
+        return True
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+    def seekable(self) -> bool:
+        return False
+
+
+def test_automatic_load_from_non_seekable_stream(binary_file, speedups):
+    # HalfDonut's binary header starts with 'solid', so auto-detection
+    # falls back from ASCII to binary, which needs to rewind. On a
+    # pipe-like stream the data must be buffered instead of seeked.
+    raw = pathlib.Path(binary_file).read_bytes()
+    loaded = mesh.Mesh.from_file(
+        'pipe.stl', fh=_NonSeekableStream(raw), speedups=speedups
+    )
+    assert len(loaded.data) > 0
+
+
+class _FailingHandle(io.RawIOBase):
+    """File handle that fails every write with ENOSPC."""
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, data: object) -> int:
+        raise OSError(28, 'No space left on device')
+
+
+def test_save_propagates_write_errors(binary_file, speedups):
+    mesh_ = mesh.Mesh.from_file(binary_file, speedups=speedups)
+    with pytest.raises(OSError, match='No space left'):
+        mesh_.save('out.stl', fh=_FailingHandle(), mode=Mode.BINARY)

--- a/tests/test_binary.py
+++ b/tests/test_binary.py
@@ -105,6 +105,26 @@ def test_automatic_load_from_non_seekable_stream(binary_file, speedups):
     assert len(loaded.data) > 0
 
 
+class _DuckReader:
+    """File-like object with only a read() method, no io.IOBase API."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buffer = io.BytesIO(data)
+
+    def read(self, size: int = -1) -> bytes:
+        return self._buffer.read(size)
+
+
+def test_load_from_duck_typed_reader(binary_file, speedups):
+    # Custom file-likes without seekable()/fileno() must not crash
+    # with AttributeError; they get buffered like pipes.
+    raw = pathlib.Path(binary_file).read_bytes()
+    loaded = mesh.Mesh.from_file(
+        'duck.stl', fh=_DuckReader(raw), speedups=speedups
+    )
+    assert len(loaded.data) > 0
+
+
 class _FailingHandle(io.RawIOBase):
     """File handle that fails every write with ENOSPC."""
 

--- a/tests/test_commandline.py
+++ b/tests/test_commandline.py
@@ -1,7 +1,8 @@
-import contextlib
+import io
+import subprocess
 import sys
 
-from stl import main
+from stl import main, mesh
 
 
 def test_main(ascii_file, binary_file, tmpdir, speedups):
@@ -39,29 +40,67 @@ def test_args(ascii_file, tmpdir):
 
 def test_ascii(binary_file, tmpdir, speedups):
     original_argv = sys.argv[:]
+    output = tmpdir.join('ascii.stl')
     try:
         sys.argv[:] = [
             'stl',
             *(['-s'] if not speedups else []),
             binary_file,
-            str(tmpdir.join('ascii.stl')),
+            str(output),
         ]
-        with contextlib.suppress(SystemExit):
-            main.to_ascii()
+        main.to_ascii()
     finally:
         sys.argv[:] = original_argv
+
+    assert output.read_binary().startswith(b'solid')
+    assert len(mesh.Mesh.from_file(str(output)).data) > 0
 
 
 def test_binary(ascii_file, tmpdir, speedups):
     original_argv = sys.argv[:]
+    output = tmpdir.join('binary.stl')
     try:
         sys.argv[:] = [
             'stl',
             *(['-s'] if not speedups else []),
             ascii_file,
-            str(tmpdir.join('binary.stl')),
+            str(output),
         ]
-        with contextlib.suppress(SystemExit):
-            main.to_binary()
+        main.to_binary()
     finally:
         sys.argv[:] = original_argv
+
+    assert not output.read_binary().startswith(b'solid')
+    assert len(mesh.Mesh.from_file(str(output)).data) > 0
+
+
+def _run_pipe(
+    entry_point: str, stdin_file: str
+) -> 'subprocess.CompletedProcess[bytes]':
+    # Piped stdin/stdout (not TTYs): the CLI must read/write binary
+    # data through the std streams' underlying buffers.
+    with open(stdin_file, 'rb') as stdin:
+        return subprocess.run(
+            [
+                sys.executable,
+                '-c',
+                f'from stl.main import {entry_point}; {entry_point}()',
+            ],
+            stdin=stdin,
+            capture_output=True,
+            check=False,
+        )
+
+
+def test_main_stdin_stdout_pipes(binary_file):
+    result = _run_pipe('main', binary_file)
+    assert result.returncode == 0, result.stderr.decode()
+
+    loaded = mesh.Mesh.from_file('out.stl', fh=io.BytesIO(result.stdout))
+    assert len(loaded.data) > 0
+
+
+def test_to_ascii_stdin_stdout_pipes(binary_file):
+    result = _run_pipe('to_ascii', binary_file)
+    assert result.returncode == 0, result.stderr.decode()
+    assert result.stdout.startswith(b'solid')

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -36,6 +36,22 @@ def test_has_speedups_consistent_with_exports(speedups):
         assert ascii_write is None
 
 
+def test_missing_speedups_package(monkeypatch):
+    """Verify _compat when no speedups package is installed at all."""
+    saved_compat = sys.modules.pop('stl._compat', None)
+    try:
+        monkeypatch.setattr(importlib.util, 'find_spec', lambda name: None)
+        compat = importlib.import_module('stl._compat')
+        assert compat.ascii_read is None
+        assert compat.ascii_write is None
+        assert compat.has_speedups() is False
+    finally:
+        if saved_compat is not None:
+            sys.modules['stl._compat'] = saved_compat
+        else:
+            sys.modules.pop('stl._compat', None)
+
+
 def test_import_error_fallback():
     """Verify _compat gracefully handles a broken speedups package."""
     fake = types.ModuleType('speedups')

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -317,6 +317,24 @@ def test_remove_duplicate_polygons_all_removes_duplicated_minority():
     assert np.allclose(result['vectors'], data['vectors'][:4])
 
 
+def test_remove_duplicate_polygons_all_with_duplicates_sorting_first():
+    # The duplicated polygon sorts BEFORE the unique ones; a
+    # successor-based mask used to keep one duplicate copy and drop
+    # the last unique polygon.
+    data = np.zeros(5, dtype=Mesh.dtype)
+    duplicated = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    data['vectors'][0] = duplicated
+    data['vectors'][1] = duplicated
+    for i in range(3):
+        data['vectors'][i + 2] = np.array(
+            [[i + 5, 0, 0], [i + 6, 0, 0], [i + 5, 1, 0]]
+        )
+
+    result = Mesh.remove_duplicate_polygons(data, RemoveDuplicates.ALL)
+    assert len(result) == 3
+    assert np.allclose(result['vectors'], data['vectors'][2:])
+
+
 def test_remove_duplicate_polygons_all_majority_duplicates_fallback():
     # Documented fallback: when removing every duplicated polygon would
     # drop half the mesh or more, ALL keeps a single copy instead.

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,5 +1,10 @@
 # type: ignore[reportAttributeAccessIssue]
+
+import io
+import math
+
 import numpy as np
+import pytest
 from stl.base import BaseMesh, RemoveDuplicates
 from stl.mesh import Mesh
 
@@ -44,7 +49,7 @@ def test_units_3d():
     mesh = Mesh(data, remove_empty_areas=False)
     mesh.update_units()
 
-    assert (mesh.areas - 2**0.5) < 0.0001
+    assert np.allclose(mesh.areas, 2**0.5 / 2)
     assert np.allclose(mesh.centroids, [1 / 3, 1 / 3, 1 / 3])
     assert np.allclose(mesh.normals, [0.0, -1.0, 1.0])
     assert np.allclose(mesh.units[0], [0.0, -0.70710677, 0.70710677])
@@ -229,3 +234,171 @@ def test_mesh_identity_equality():
     assert lookup[mesh_b] == 'b'
 
     assert mesh_a != 'not a mesh'
+
+
+def _single_triangle_mesh() -> Mesh:
+    data = np.zeros(1, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    return Mesh(data, remove_empty_areas=False)
+
+
+def test_transform_updates_normals():
+    # transform() used to rotate the vectors but leave the stored
+    # normals at their pre-transform values.
+    mesh = _single_triangle_mesh()
+    rotation_x_90 = np.array(
+        [
+            [1, 0, 0, 0],
+            [0, 0, -1, 0],
+            [0, 1, 0, 0],
+            [0, 0, 0, 1],
+        ],
+        dtype=np.float64,
+    )
+    mesh.transform(rotation_x_90)
+
+    transformed_normals = mesh.normals.copy()
+    mesh.update_normals()
+    utils.array_equals(transformed_normals, mesh.normals)
+
+
+def test_translate_and_transform_refresh_min_max():
+    mesh = _single_triangle_mesh()
+
+    # Populate the lazy caches before mutating.
+    assert np.allclose(mesh.min_, [0, 0, 0])
+    assert np.allclose(mesh.max_, [1, 1, 0])
+
+    mesh.translate([10, 20, 30])
+    assert np.allclose(mesh.min_, [10, 20, 30])
+    assert np.allclose(mesh.max_, [11, 21, 30])
+
+    translation = np.identity(4)
+    translation[0:3, 3] = [-10, -20, -30]
+    mesh.transform(translation)
+    assert np.allclose(mesh.min_, [0, 0, 0])
+    assert np.allclose(mesh.max_, [1, 1, 0])
+
+
+def test_rotate_refreshes_min_max():
+    data = np.zeros(1, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[1, 0, 0], [2, 0, 0], [1, 1, 0]])
+    mesh = Mesh(data, remove_empty_areas=False)
+
+    assert np.allclose(mesh.min_, [1, 0, 0])
+    assert np.allclose(mesh.max_, [2, 1, 0])
+
+    mesh.rotate([0.5, 0.0, 0.0], math.radians(180))
+    assert np.allclose(mesh.min_, [1, -1, 0], atol=1e-6)
+    assert np.allclose(mesh.max_, [2, 0, 0], atol=1e-6)
+
+
+def test_remove_duplicate_polygons_with_equal_vertex_sums():
+    # Two DISTINCT triangles whose per-axis vertex sums match used to
+    # be treated as duplicates, silently dropping one of them.
+    data = np.zeros(2, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [2, 1, 0]])
+    data['vectors'][1] = np.array([[0, 0, 0], [2, 0, 0], [1, 1, 0]])
+
+    result = Mesh.remove_duplicate_polygons(data, RemoveDuplicates.SINGLE)
+    assert len(result) == 2
+
+
+def test_remove_duplicate_polygons_all_removes_duplicated_minority():
+    data = np.zeros(6, dtype=Mesh.dtype)
+    for i in range(4):
+        data['vectors'][i] = np.array([[i, 0, 0], [i + 1, 0, 0], [i, 1, 0]])
+    duplicated = np.array([[7, 7, 7], [8, 7, 7], [7, 8, 7]])
+    data['vectors'][4] = duplicated
+    data['vectors'][5] = duplicated
+
+    result = Mesh.remove_duplicate_polygons(data, RemoveDuplicates.ALL)
+    assert len(result) == 4
+    assert np.allclose(result['vectors'], data['vectors'][:4])
+
+
+def test_remove_duplicate_polygons_all_majority_duplicates_fallback():
+    # Documented fallback: when removing every duplicated polygon would
+    # drop half the mesh or more, ALL keeps a single copy instead.
+    data = np.zeros(4, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    data['vectors'][1] = data['vectors'][0]
+    data['vectors'][2] = np.array([[5, 5, 5], [6, 5, 5], [5, 6, 5]])
+    data['vectors'][3] = data['vectors'][2]
+
+    result = Mesh.remove_duplicate_polygons(data, RemoveDuplicates.ALL)
+    assert len(result) == 2
+
+
+def test_save_load_accept_plain_int_modes(speedups):
+    mesh = _single_triangle_mesh()
+    mesh.speedups = False
+
+    ascii_fh = io.BytesIO()
+    mesh.save('ints.stl', fh=ascii_fh, mode=1)
+    assert ascii_fh.getvalue().startswith(b'solid')
+
+    binary_fh = io.BytesIO()
+    mesh.save('ints.stl', fh=binary_fh, mode=2)
+    assert not binary_fh.getvalue().startswith(b'solid')
+
+    loaded = Mesh.from_file(
+        'ints.stl',
+        fh=io.BytesIO(binary_fh.getvalue()),
+        mode=2,
+        speedups=False,
+    )
+    assert np.allclose(loaded.vectors, mesh.vectors)
+
+    with pytest.raises(ValueError, match=r'[Mm]ode'):
+        mesh.save('ints.stl', fh=io.BytesIO(), mode=7)
+
+
+def _tetrahedron() -> Mesh:
+    # Consistently wound (outward) closed tetrahedron.
+    a, b, c, d = (
+        np.array([0, 0, 0]),
+        np.array([1, 0, 0]),
+        np.array([0, 1, 0]),
+        np.array([0, 0, 1]),
+    )
+    data = np.zeros(4, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([a, c, b])
+    data['vectors'][1] = np.array([a, b, d])
+    data['vectors'][2] = np.array([a, d, c])
+    data['vectors'][3] = np.array([b, c, d])
+    return Mesh(data, remove_empty_areas=False)
+
+
+def test_is_closed_exact_closed_mesh():
+    assert _tetrahedron().check(exact=True)
+
+
+def test_is_closed_exact_with_reversed_winding():
+    # One face is wound backwards while its stored normal still points
+    # the way the original winding implied. The orientation flag marks
+    # the triangle as reversed and flips its edges back, so the mesh is
+    # still recognized as closed.
+    mesh = _tetrahedron()
+    mesh.vectors[0] = mesh.vectors[0][::-1]
+    assert mesh.check(exact=True)
+
+
+def test_is_closed_exact_open_mesh(caplog):
+    assert not _single_triangle_mesh().check(exact=True)
+    assert 'mesh is not closed' in caplog.text
+
+
+def test_is_closed_exact_duplicated_triangle():
+    # Two identical triangles produce colliding directed edges.
+    data = np.zeros(2, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    data['vectors'][1] = data['vectors'][0]
+    assert not Mesh(data, remove_empty_areas=False).check(exact=True)
+
+
+def test_is_closed_heuristic(caplog):
+    assert _tetrahedron().check(exact=False)
+    assert 'not exact' in caplog.text
+
+    assert not _single_triangle_mesh().check(exact=False)

--- a/tests/test_mesh_properties.py
+++ b/tests/test_mesh_properties.py
@@ -1,5 +1,8 @@
+import logging
+
 import numpy as np
 import pytest
+from stl.mesh import Mesh
 
 from stl import stl
 
@@ -54,19 +57,8 @@ def test_mass_properties_for_moon(binary_ascii_path, speedups):
     )
 
 
-@pytest.mark.parametrize('filename', ('Star.stl', 'StarWithEmptyHeader.stl'))
-def test_mass_properties_for_star(binary_ascii_path, filename, speedups):
-    """
-    Checks the results of method get_mass_properties() on
-    STL ASCII and binary files Star.stl and
-    STL binary file StarWithEmptyHeader.stl (with no header)
-    One checks the results obtained with stl
-    with the ones obtained with meshlab
-    """
-    filename = binary_ascii_path / filename
-    if not filename.exists():
-        pytest.skip('STL file does not exist')
-    mesh = stl.StlMesh(str(filename), speedups=speedups)
+def _check_star_mass_properties(filename: str, speedups: bool) -> None:
+    mesh = stl.StlMesh(filename, speedups=speedups)
     volume, cog, inertia = mesh.get_mass_properties()
     assert close([volume], [1.416599])
     assert close(cog, [1.299040, 0.170197, 1.499999])
@@ -77,6 +69,26 @@ def test_mass_properties_for_star(binary_ascii_path, filename, speedups):
             [+0.000000, +0.991236, +0.000000],
             [-0.000000, +0.000000, +0.509550],
         ],
+    )
+
+
+def test_mass_properties_for_star(binary_ascii_path, speedups):
+    """
+    Checks the results of method get_mass_properties() on
+    STL ASCII and binary files Star.stl
+    One checks the results obtained with stl
+    with the ones obtained with meshlab
+    """
+    _check_star_mass_properties(str(binary_ascii_path / 'Star.stl'), speedups)
+
+
+def test_mass_properties_for_star_with_empty_header(binary_path, speedups):
+    """
+    Checks get_mass_properties() on the binary-only
+    StarWithEmptyHeader.stl (with no header).
+    """
+    _check_star_mass_properties(
+        str(binary_path / 'StarWithEmptyHeader.stl'), speedups
     )
 
 
@@ -123,3 +135,18 @@ def test_is_convex(binary_ascii_path, speedups, filename, expected_result):
     filepath = binary_ascii_path / filename
     mesh = stl.StlMesh(str(filepath), speedups=speedups)
     assert mesh.is_convex() == expected_result
+
+
+def test_mass_properties_open_mesh_warns_and_returns(caplog):
+    """An open mesh warns instead of raising and still returns values."""
+    data = np.zeros(1, dtype=Mesh.dtype)
+    data['vectors'][0] = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    open_mesh = Mesh(data, remove_empty_areas=False)
+
+    with caplog.at_level(logging.WARNING):
+        volume, cog, inertia = open_mesh.get_mass_properties()
+
+    assert 'mesh is not closed' in caplog.text
+    assert np.isclose(volume, 0)
+    assert cog.shape == (3,)
+    assert inertia.shape == (3, 3)

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -390,11 +390,14 @@ class TestPlyHelpers:
         ):
             ply._read_binary_faces(fh, face, '<')
 
-    def test_read_binary_faces_scans_until_it_finds_the_list_property(self):
+    def test_read_binary_faces_consumes_scalar_prefix(self):
+        # The stream contains the material_index byte (9) followed by
+        # the list count (3); the scalar must be consumed, not misread
+        # as the count.
         face = _make_face_element(scalar_prefix=True)
 
         faces = ply._read_binary_faces(
-            io.BytesIO(struct.pack('<Biii', 3, 0, 1, 2)),
+            io.BytesIO(struct.pack('<BBiii', 9, 3, 0, 1, 2)),
             face,
             '<',
         )
@@ -457,9 +460,7 @@ class TestPlyHelpers:
         )
         face = _make_face_element()
 
-        with pytest.raises(
-            ValueError, match='Cannot skip element with list properties'
-        ):
+        with pytest.raises(ValueError, match='list properties'):
             ply._skip_binary_elements(
                 io.BytesIO(), [vertex, edge, face], vertex, face
             )
@@ -556,3 +557,157 @@ class TestPlyHelpers:
         )
 
         assert captured['name'] == ''
+
+
+def _ply_header(*lines: str) -> bytes:
+    return ('\n'.join(('ply', *lines, 'end_header')) + '\n').encode('ascii')
+
+
+_TRIANGLE_VERTEX_LINES = (
+    'element vertex 3',
+    'property float x',
+    'property float y',
+    'property float z',
+)
+_TRIANGLE_VECTORS = np.array(
+    [[0, 0, 0], [1, 0, 0], [0, 1, 0]],
+    dtype=np.float32,
+)
+
+
+def test_read_binary_skips_elements_declared_before_vertex():
+    # Spec-legal PLY files may declare elements (camera, material, ...)
+    # before the vertex element; their data used to be consumed as
+    # vertex data, silently corrupting the mesh.
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        'element camera 1',
+        'property float focal',
+        'property float aperture',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    body = (
+        struct.pack('<2f', 35.0, 1.8)
+        + struct.pack('<9f', 0, 0, 0, 1, 0, 0, 0, 1, 0)
+        + struct.pack('<B3i', 3, 0, 1, 2)
+    )
+    data, _name = ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+    assert len(data) == 1
+    assert np.allclose(data['vectors'][0], _TRIANGLE_VECTORS)
+
+
+def test_vertex_element_with_list_property_raises_value_error():
+    # Used to crash with a raw KeyError: 'list'.
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'property list uchar uchar rgba',
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    with pytest.raises(ValueError, match='list'):
+        ply.read_ply(io.BytesIO(header), mesh.Mesh.dtype)
+
+
+def test_binary_face_scalar_properties_around_list_are_consumed():
+    # Scalar face properties before/after the list property used to be
+    # misread as the list count / next face's data.
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property uchar material_id',
+        'property list uchar int vertex_indices',
+        'property float quality',
+    )
+    body = struct.pack('<9f', 0, 0, 0, 1, 0, 0, 0, 1, 0) + struct.pack(
+        '<BB3if', 7, 3, 0, 1, 2, 0.5
+    )
+    data, _name = ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+    assert len(data) == 1
+    assert np.allclose(data['vectors'][0], _TRIANGLE_VECTORS)
+
+
+def test_ascii_face_scalar_property_before_list_is_consumed():
+    header = _ply_header(
+        'format ascii 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property int material_id',
+        'property list uchar int vertex_indices',
+    )
+    body = b'0 0 0\n1 0 0\n0 1 0\n7 3 0 1 2\n'
+    data, _name = ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+    assert len(data) == 1
+    assert np.allclose(data['vectors'][0], _TRIANGLE_VECTORS)
+
+
+def _ascii_triangle_with_face(face_line: bytes) -> io.BytesIO:
+    header = _ply_header(
+        'format ascii 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    return io.BytesIO(header + b'0 0 0\n1 0 0\n0 1 0\n' + face_line)
+
+
+def test_binary_second_list_property_on_face_is_skipped():
+    # A second list property (e.g. texture coordinates) after the
+    # vertex index list must be consumed per its own count field.
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 2',
+        'property list uchar int vertex_indices',
+        'property list uchar float texcoords',
+    )
+    face = struct.pack('<B3i', 3, 0, 1, 2) + struct.pack(
+        '<B6f', 6, 0, 0, 1, 0, 0, 1
+    )
+    body = struct.pack('<9f', 0, 0, 0, 1, 0, 0, 0, 1, 0) + face * 2
+    data, _name = ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+    assert len(data) == 2
+    assert np.allclose(data['vectors'][0], _TRIANGLE_VECTORS)
+
+
+def test_ascii_face_element_without_list_property_raises():
+    header = _ply_header(
+        'format ascii 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property int material_id',
+    )
+    body = b'0 0 0\n1 0 0\n0 1 0\n7\n'
+    with pytest.raises(ValueError, match='no list property'):
+        ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+
+def test_binary_element_before_vertex_with_list_property_raises():
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        'element strips 1',
+        'property list uchar int strip_indices',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    with pytest.raises(ValueError, match='list propert'):
+        ply.read_ply(io.BytesIO(header), mesh.Mesh.dtype)
+
+
+def test_face_index_out_of_range_raises_value_error():
+    with pytest.raises(ValueError, match='index'):
+        ply.read_ply(_ascii_triangle_with_face(b'3 0 1 99\n'), mesh.Mesh.dtype)
+
+
+def test_negative_face_index_raises_value_error():
+    # Negative indices used to wrap around silently via numpy indexing.
+    with pytest.raises(ValueError, match='index'):
+        ply.read_ply(_ascii_triangle_with_face(b'3 0 1 -1\n'), mesh.Mesh.dtype)

--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -702,6 +702,51 @@ def test_binary_element_before_vertex_with_list_property_raises():
         ply.read_ply(io.BytesIO(header), mesh.Mesh.dtype)
 
 
+def test_truncated_pre_vertex_element_raises():
+    # 8 bytes of camera data declared, only 4 present.
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        'element camera 1',
+        'property float focal',
+        'property float aperture',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    body = struct.pack('<f', 35.0)
+    with pytest.raises(ValueError, match='skipping element'):
+        ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+
+def test_truncated_element_between_vertex_and_face_raises():
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element extra 1',
+        'property double weight',
+        'element face 1',
+        'property list uchar int vertex_indices',
+    )
+    body = struct.pack('<9f', 0, 0, 0, 1, 0, 0, 0, 1, 0) + b'\x00' * 4
+    with pytest.raises(ValueError, match='skipping element'):
+        ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+
+def test_truncated_face_scalar_property_raises():
+    header = _ply_header(
+        'format binary_little_endian 1.0',
+        *_TRIANGLE_VERTEX_LINES,
+        'element face 1',
+        'property uchar material_id',
+        'property list uchar int vertex_indices',
+    )
+    # Vertex data is complete; the face row is missing entirely, so
+    # reading the material_id scalar hits EOF.
+    body = struct.pack('<9f', 0, 0, 0, 1, 0, 0, 0, 1, 0)
+    with pytest.raises(ValueError, match='scalar'):
+        ply.read_ply(io.BytesIO(header + body), mesh.Mesh.dtype)
+
+
 def test_face_index_out_of_range_raises_value_error():
     with pytest.raises(ValueError, match='index'):
         ply.read_ply(_ascii_triangle_with_face(b'3 0 1 99\n'), mesh.Mesh.dtype)

--- a/tox.ini
+++ b/tox.ini
@@ -95,8 +95,9 @@ deps =
     matplotlib>=3.8
 set_env =
     NUMPY_STL_RUN_DOCS_EXAMPLES = 1
+    COVERAGE_FILE = {toxworkdir}/.coverage.docs-examples
 commands =
-    pytest --basetemp={envtmpdir}/tmp tests/docs_examples
+    pytest --basetemp={envtmpdir}/tmp --cov-report= tests/docs_examples
 
 # ── Coverage ─────────────────────────────────────────────────
 
@@ -107,6 +108,7 @@ deps = coverage>=7.0
 depends =
     py{310,311,312,313}-numpy{1,2}
     speedups
+    docs-examples
 set_env =
     COVERAGE_FILE = {toxworkdir}/.coverage
 commands =


### PR DESCRIPTION
## Summary

A systematic bug scan of the codebase (5 scoped reviewers + adversarial runtime verification of every candidate finding) surfaced ~26 real defects. This PR fixes all of them, test-first: every fix has a regression test that was written and watched fail before the fix was applied.

### Data corruption / crash fixes
- **Binary STL count read as signed `'<i'`** (`stl/stl.py`): counts with the high bit set went negative, passed `count < MAX_COUNT`, and `np.fromfile(count=-1)` silently read the whole file. Now `'<I'` on both read and write.
- **PLY reader layout assumptions** (`stl/ply.py`): elements declared before `vertex` were consumed as vertex data (silent corruption or crash on spec-legal files); scalar/extra-list face properties around the index list were misread as the list count; out-of-range face indices crashed with raw `IndexError` and negative indices wrapped around silently; list-typed vertex properties crashed with `KeyError: 'list'`. All fixed with descriptive `ValueError`s and full per-row property consumption.
- **CLI broken for pipes** (`stl/main.py`, `stl/stl.py`): `stl in.stl > out` and `cat in.stl | stl2ascii` crashed (text-mode std stream defaults). Now uses `sys.std{in,out}.buffer`, buffers non-seekable streams so auto-detection can rewind (binary files with a `solid` header now load from stdin — previously impossible), and disables the speedups C paths on non-seekable streams (they require seekable files, as do `np.tofile()` and the `tell()` sanity check).
- **ASCII writer precision** (`stl/stl.py`): `'{:f}'` flattened |v| < 5e-7 to `0.000000`. Now `'{:.9g}'` — lossless float32 round-trips, plain decimal for everyday magnitudes, scientific (spec-conformant) only for extremes.
- **`save()` swallowed every `OSError`**: disk-full/broken-pipe failures exited successfully with truncated output. Now propagate.

### Wrong results
- `transform()` rotated vectors but left stored normals stale.
- `translate()`/`transform()`/`rotate_using_matrix()` never invalidated the cached `min_`/`max_` bounding box.
- `remove_duplicate_polygons` keyed on per-axis vertex sums — distinct triangles with equal sums were silently dropped.
- Recursive blank-line skip in the ASCII reader hit `RecursionError` on ~1000 consecutive blank lines.
- Empty STL files raised an opaque `TypeError`; now a descriptive `ValueError`.
- `save(mode=1)` rejected valid int modes; now normalized via `Mode(mode)`.
- 3MF: missing vertex/triangle attributes and out-of-range indices now raise descriptive `ValueError`s instead of raw `KeyError`/`IndexError`/silent wraparound.
- Docs: `get_mass_properties*` no longer claims a `RuntimeError` that was never raised (kept the lenient warn-and-compute behavior by design); the `RemoveDuplicates.ALL` majority fallback is now documented and pinned by a test.

### Test-suite repairs (tests that could never fail)
- `stl_corruption.test_duplicate_polygons` assigned `vectors[0]` three times.
- `test_units_3d` asserted `(areas - √2) < 0.0001` — one-sided against the wrong reference (true area is √2/2); passed for any value below 1.41.
- CLI tests suppressed `SystemExit` with no output assertions.
- The PLY scalar-prefix test omitted the scalar byte from its stream, pinning the buggy behavior.
- `StarWithEmptyHeader.stl` ascii variants silently skipped forever (file is binary-only).
- Removed `# pragma: no cover` from `is_closed()` and `utils.b()` and covered their branches — the 100% lines+branches figure is now honest.

### CI / packaging
- **PyPI publishing is now gated on the full test suite** (`publish.yml` calls `ci.yml` via `workflow_call`; previously a tag push published without any tests running).
- CodeQL workflow upgraded from EOL `codeql-action@v2`/`checkout@v3` to `@v4`/`@v6`.
- `docs-examples` coverage is now written to the tox workdir and included in the combine gate (tox + CI artifact upload).
- numpy dependency declares the tested lower bound (`>=1.24`; structured-dtype `np.fromiter` needs ≥1.23).

## Test plan
- [x] 49 new regression tests, each watched fail before its fix (TDD red/green)
- [x] Full suite: 328 passed, 23 skipped (env-gated), with the real speedups C extension active
- [x] Coverage: 100% lines and branches with the pragmas removed
- [x] `tox -e lint` and `tox -e pyrefly` pass
- [x] CLI pipe smoke tests: `stl Star.stl > out` and `cat Star.stl | stl2ascii` exit 0 with valid output